### PR TITLE
Add .pre-commit-config.yaml file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+# HOWTO: https://pre-commit.com/#usage
+# pip3 install pre-commit
+# pre-commit install
+
+repos:
+-   repo: https://github.com/ambv/black
+    rev: 19.3b0
+    hooks:
+    - id: black
+      language_version: python3.6
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.2.3
+    hooks:
+    - id: check-added-large-files
+    - id: check-ast
+    - id: check-merge-conflict
+    - id: check-yaml
+    - id: detect-private-key
+      exclude: tests/integration/conftest.py
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
+    - id: flake8
+      args:
+        - --max-line-length=100
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.711
+    hooks:
+    -   id: mypy
+        args: [--no-strict-optional, --ignore-missing-imports]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,11 +3,6 @@
 # pre-commit install
 
 repos:
--   repo: https://github.com/ambv/black
-    rev: 19.3b0
-    hooks:
-    - id: black
-      language_version: python3.6
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3
     hooks:
@@ -16,7 +11,6 @@ repos:
     - id: check-merge-conflict
     - id: check-yaml
     - id: detect-private-key
-      exclude: tests/integration/conftest.py
     - id: end-of-file-fixer
     - id: trailing-whitespace
     - id: flake8


### PR DESCRIPTION
This only enables `.pre-commit-config.yaml` file and enable checker.

Next PR will review the rest code. Each python file separatelly.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>