### PR TITLE
Fixes #17: Use f31 for generating Dockerfile and remove command for helps

### DIFF
--- a/container_workflow_tool/config/f28.yaml
+++ b/container_workflow_tool/config/f28.yaml
@@ -42,8 +42,7 @@ v1:
   urls: !include share/urls.yaml
 
   commands:
-    2: "for ver in */; do make $ver/root/help.1; done"
-    3: "sed -i 's|registry.fedoraproject.org/f[0-9]*/|registry.fedoraproject.org/f28/|' */Dockerfile.fedora"
+    2: "sed -i 's|registry.fedoraproject.org/f[0-9]*/|registry.fedoraproject.org/f28/|' */Dockerfile.fedora"
 
   # format:
   # - image_name

--- a/container_workflow_tool/config/f29.yaml
+++ b/container_workflow_tool/config/f29.yaml
@@ -42,8 +42,7 @@ v1:
   urls: !include share/urls.yaml
 
   commands:
-    2: "for ver in */; do make $ver/root/help.1; done"
-    3: "sed -i 's|registry.fedoraproject.org/f[0-9]*/|registry.fedoraproject.org/f29/|' */Dockerfile.fedora"
+    2: "sed -i 's|registry.fedoraproject.org/f[0-9]*/|registry.fedoraproject.org/f29/|' */Dockerfile.fedora"
 
   # format:
   # - image_name

--- a/container_workflow_tool/config/f30.yaml
+++ b/container_workflow_tool/config/f30.yaml
@@ -34,7 +34,7 @@ v1:
 ##-5.0      - passenger
 ##-5.28      - perl
 ##-7.2      - php
-##-3.7      - python3
+        - python3
         - ruby
 
   current: *f30
@@ -42,8 +42,7 @@ v1:
   urls: !include share/urls.yaml
 
   commands:
-    2: "make generate"
-    3: "sed -i 's|registry.fedoraproject.org/f[0-9]*/|registry.fedoraproject.org/f30/|' */Dockerfile.fedora"
+    2: "sed -i 's|registry.fedoraproject.org/f[0-9]*/|registry.fedoraproject.org/f30/|' */Dockerfile.fedora"
 
   # format:
   # - image_name

--- a/container_workflow_tool/config/f31.yaml
+++ b/container_workflow_tool/config/f31.yaml
@@ -188,7 +188,7 @@ v1:
       git_branch: "fFEDORA"
       user: "pkubat"
       commands:
-        4: "sed -i 's|registry.fedoraproject.org/fedora:[0-9]*|registry.fedoraproject.org/fedora:29|' */Dockerfile.fedora"
+        4: "sed -i 's|registry.fedoraproject.org/fedora:[0-9]*|registry.fedoraproject.org/fedora:31|' */Dockerfile.fedora"
     toolchain:
       bz_version: "FEDORA"
       component: "toolchain"

--- a/container_workflow_tool/config/f31.yaml
+++ b/container_workflow_tool/config/f31.yaml
@@ -42,8 +42,7 @@ v1:
   urls: !include share/urls.yaml
 
   commands:
-    2: "for ver in */; do make $ver/root/help.1; done"
-    3: "sed -i 's|registry.fedoraproject.org/f[0-9]*/|registry.fedoraproject.org/f29/|' */Dockerfile.fedora"
+    2: "sed -i 's|registry.fedoraproject.org/f[0-9]*/|registry.fedoraproject.org/f31/|' */Dockerfile.fedora"
 
   # format:
   # - image_name


### PR DESCRIPTION
help.1 should be generated by the command `make generate-all`.
It is not needed to generate it twice.

For cycle involves also `examples` and `imagestreams` directory.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>