### PR TITLE
Add possibility to log some functions into file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     - id: trailing-whitespace
     - id: flake8
       args:
-        - --max-line-length=100
+        - --max-line-length=170
       ignore: W605
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.711

--- a/container_workflow_tool/cli_common.py
+++ b/container_workflow_tool/cli_common.py
@@ -37,6 +37,8 @@ class CliCommon(object):
                             action='append')
         parser.add_argument('--disable-klist', action='store_true',
                             help='Disables getting kerberos token by klist')
+        parser.add_argument('--output-file',
+                            help='Specify output file, where some actions stores computer readable results')
         parser.add_argument('--base', nargs='?')
         subparsers = parser.add_subparsers(dest='command')
         subparsers.required = True
@@ -81,6 +83,7 @@ class CliCommon(object):
         --do-set             - Use a specific set of images instead of all from the config (use dist-git names)
         --tmp                - Overrides default temporary working directory
         --disable-klist      - Disables getting kerberos token by klist
+        --output-file        - Specify file, where the output will be stored
         {args}
 """
         return action_help

--- a/container_workflow_tool/utility.py
+++ b/container_workflow_tool/utility.py
@@ -5,6 +5,8 @@ import logging
 
 import textwrap
 
+from pathlib import Path
+
 
 class RebuilderError(Exception):
     pass
@@ -19,6 +21,8 @@ class ArgParser(argparse.ArgumentParser):
 
 # Utility textwrap functions
 def _2sp(a): return textwrap.indent(a, '  ')
+
+
 def _4sp(a): return textwrap.indent(a, '    ')
 
 
@@ -60,6 +64,13 @@ def _get_hostname_url(config):
     # default to "https://src.fedoraproject.org"
     git_url = getattr(config, "hostname_url", None)
     return git_url
+
+
+def save_output(output: str, output_file: str):
+    print(output)
+    out_file = Path.cwd() / output_file
+    with out_file.open("a") as fp:
+        fp.write(output)
 
 
 def setup_logger(logger_id, level=logging.INFO):


### PR DESCRIPTION
This allows container-workflow-tool to log some actions into a file specified by
`--output-file` option.
This option can help with automation.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>