### PR TITLE
Allow write to file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     - id: trailing-whitespace
     - id: flake8
       args:
-        - --max-line-length=100
+        - --max-line-length=170
       ignore: W605
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.711

--- a/container_workflow_tool/cli_common.py
+++ b/container_workflow_tool/cli_common.py
@@ -37,6 +37,8 @@ class CliCommon(object):
                             action='append')
         parser.add_argument('--disable-klist', action='store_true',
                             help='Disables getting kerberos token by klist')
+        parser.add_argument('--output-file',
+                            help='Specify output file, where some actions stores computer readable results')
         parser.add_argument('--base', nargs='?')
         subparsers = parser.add_subparsers(dest='command')
         subparsers.required = True
@@ -57,7 +59,9 @@ class CliCommon(object):
         parsers['git'].add_argument('--rebuild-reason', help='Use a custom reason for rebuilding')
         parsers['git'].add_argument('--commit-msg', help='Use a custom message instead of the default one')
         parsers['git'].add_argument('--check-script', help='Script/command to be run when checking repositories')
-        parsers['build'].add_argument('--repo-url', help='Set the url of a .repo file to be used when building the image')
+        parsers['build'].add_argument(
+            '--repo-url', help='Set the url of a .repo file to be used when building the image'
+        )
         return parser
 
     def cli_usage(self):
@@ -74,13 +78,15 @@ class CliCommon(object):
         --base               - Specific base image release, required for some actions
         --clear-cache        - Clears tmp dir before running the command
         --latest-release     - Work with latest brew builds by release value
-        --config             - Overrides default configuration file, expects the name of file a inside the config folder, optionally takes image_set argument
+        --config             - Overrides default configuration file,
+                               expects the name of file a inside the config folder, optionally takes image_set argument
                                example usage: --config default.yaml:fedora27
         --do-image           - Use a custom set of images instead of all from the config (use dist-git names)
         --exclude-image      - Exclude an image from the list of images defined by config (use dist-git names)
         --do-set             - Use a specific set of images instead of all from the config (use dist-git names)
         --tmp                - Overrides default temporary working directory
         --disable-klist      - Disables getting kerberos token by klist
+        --output-file        - Save output of cwt into a output_file
         {args}
 """
         return action_help
@@ -91,7 +97,8 @@ class CliCommon(object):
         merge            - Clone dist-git, merges content from primary branch to future branches
         cloneupstream    - Clones upstream git repositories
         clonedownstream  - Pulls downstream dist-git repositories and does not make any further changes to them
-        pullupstream     - Clone dist-git, clone upstream, copy content from upstream repo to dist-git, commit (all images; does not push, manual review/push needed)
+        pullupstream     - Clone dist-git, clone upstream, copy content from upstream repo to dist-git,
+                           commit (all images; does not push, manual review/push needed)
         push             - Pushes local changes for all components into downstream dist-git repository
         rebase           - Clone dist-git, bump release, commit, push, build in brew
         show             - Walk trough git repositories and show changes for each

--- a/container_workflow_tool/main.py
+++ b/container_workflow_tool/main.py
@@ -14,6 +14,7 @@ import logging
 
 from git import Repo, GitError
 from typing import List, Any
+from pathlib import Path
 
 import container_workflow_tool.utility as u
 from container_workflow_tool.koji import KojiAPI
@@ -59,9 +60,10 @@ class ImageRebuilder:
         self.check_script = None
         self.image_set = None
         self.disable_klist = None
+        self.output_file = None
         self.latest_release = None
 
-        self._setup_logger()
+        self.logger = self._setup_logger()
         self.set_config(self.conf_name, release=release)
 
     @classmethod
@@ -71,7 +73,22 @@ class ImageRebuilder:
         """
         rebuilder = ImageRebuilder(base_image=args.base)
         rebuilder._setup_args(args)
+        rebuilder.setup_log_to_file()
         return rebuilder
+
+    def setup_log_to_file(self):
+        # File handler
+        if self.output_file:
+            out_file = Path(self.output_file)
+            # If file is not absolute lets create out_file from current directory
+            if not out_file.is_absolute():
+                out_file = Path.cwd() / self.output_file
+            file_handler = logging.FileHandler(out_file)
+            file_handler.setLevel(logging.INFO)
+            file_format_str = "%(message)s"
+            file_formatter = logging.Formatter(file_format_str)
+            file_handler.setFormatter(file_formatter)
+            self.logger.addHandler(file_handler)
 
     def _setup_args(self, args):
         self.args = args
@@ -107,6 +124,8 @@ class ImageRebuilder:
             self.disable_klist = args.disable_klist
         if getattr(args, 'latest_release', None) is not None and args.latest_release:
             self.latest_release = args.latest_release
+        if getattr(args, 'output_file', None) is not None and args.output_file:
+            self.output_file = args.output_file
 
         # Image set to build
         if getattr(args, 'image_set', None) is not None and args.image_set:
@@ -371,7 +390,7 @@ class ImageRebuilder:
                 result += self.brewapi.get_time_built(nvr) + '|'
             result += str(len(archives))
             output.append(result)
-        return '\n'.join(output)
+        return output
 
     def set_config(self, conf_name: str, release: str = "current"):
         """
@@ -445,7 +464,7 @@ class ImageRebuilder:
     def list_images(self):
         """Prints list of images that we work with"""
         for i in self._get_images():
-            print(i["component"])
+            self.logger.info(i["component"])
 
     def print_upstream(self):
         """Prints the upstream name and url for images used in config"""
@@ -454,7 +473,7 @@ class ImageRebuilder:
                                  i["git_url"]).group(1)
             msg = f"{i.get('component')} {i.get('name')} {ups_name} " \
                   f"{i.get('git_url')} {i.get('git_path')} {i.get('git_branch')}"
-            print(f"{msg}")
+            self.logger.info(msg)
 
     def show_config_contents(self):
         """Prints the symbols and values of configuration used"""
@@ -487,7 +506,8 @@ class ImageRebuilder:
         Returns:
             str: Resulting brew build text
         """
-        print(self.get_brew_builds(print_time=print_time))
+        for builds in self.get_brew_builds(print_time=print_time):
+            self.logger.info(builds)
 
     # Dist-git method wrappers
     @needs_distgit

--- a/container_workflow_tool/utility.py
+++ b/container_workflow_tool/utility.py
@@ -19,6 +19,8 @@ class ArgParser(argparse.ArgumentParser):
 
 # Utility textwrap functions
 def _2sp(a): return textwrap.indent(a, '  ')
+
+
 def _4sp(a): return textwrap.indent(a, '    ')
 
 
@@ -29,8 +31,8 @@ def flatten_list(input_list):
         if not isinstance(sl, list):
             flattened.append(sl)
         else:
-            for l in sl:
-                flattened.append(l)
+            for ll in sl:
+                flattened.append(ll)
     return flattened
 
 


### PR DESCRIPTION
This allows container-workflow-tool to log some actions into a file specified by
--output-file option.
This option can help with automation.

Signed-off-by: Petr "Stone" Hracek phracek@redhat.com