### PR TITLE
This pull request adds support for testing in Testing Farm

### DIFF
--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -1,0 +1,195 @@
+name: Fedora-PR-tests@TF
+
+on:
+  issue_comment:
+    types:
+      - created
+jobs:
+  build:
+    # This job only runs for '[test]' pull request comments by owner, member
+    name: Schedule test on Testing Farm service for Fedora
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [py36, py37, py38, py39]
+    if: |
+      github.event.issue.pull_request
+      && contains(github.event.comment.body, '/test')
+      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
+    outputs:
+      REQ_ID: ${{steps.sched_test.outputs.REQ_ID}}
+      SHA: ${{steps.sha.outputs.SHA}}
+    steps:
+      - name: Get pull request number
+        id: pr_nr
+        run: |
+          PR_URL="${{ github.event.comment.issue_url }}"
+          echo "::set-output name=PR_NR::${PR_URL##*/}"
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: "refs/pull/${{ steps.pr_nr.outputs.PR_NR }}/head"
+
+      - name: Get sha
+        id: sha
+        run: |
+          # Store SHA into outputs
+          echo "::set-output name=SHA::$(git rev-parse HEAD)"
+
+      - name: Create status check to pending
+        id: pending
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Create a JSON file for Testing Farm in order to schedule a CI testing job
+          cat << EOF > pending.json
+          {
+            "sha": "${{steps.sha.outputs.SHA}}",
+            "state": "pending",
+            "context": "Testing Farm",
+            "target_url": "http://artifacts.dev.testing-farm.io/${{ steps.sched_test.outputs.req_id }}/pipeline.log"
+          }
+          EOF
+          echo "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{steps.sha.outputs.SHA}}"
+          # GITHUB_TOKEN is used for updating pull request status.
+          # It is provided by GitHub https://docs.github.com/en/actions/reference/authentication-in-a-workflow#about-the-github_token-secret
+          curl -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{steps.sha.outputs.SHA}} \
+            --data @pending.json
+          echo "::set-output name=GITHUB_REPOSITORY::$GITHUB_REPOSITORY"
+
+      - name: Schedule a test on Testing Farm for Fedora
+        id: sched_test
+        run: |
+          # Update ubuntu-latest in order to install curl and jq
+          apt update && apt -y install curl jq
+          cat << EOF > request.json
+          {
+            "api_key": "${{ secrets.TF_PUBLIC_API_KEY }}",
+            "test": {"fmf": {
+              "url": "https://github.com/sclorg/sclorg-testing-farm",
+              "ref": "main",
+              "name": "cwt"
+            }},
+            "environments": [{
+              "arch": "x86_64",
+              "os": {"compose": "Fedora-34"},
+              "variables": {
+                "REPO_URL": "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY",
+                "REPO_NAME": "$GITHUB_REPOSITORY",
+                "PR_NUMBER": "${{ steps.pr_nr.outputs.PR_NR }}",
+                "TOX": "${{ matrix.python }}",
+              }
+            }]
+          }
+          EOF
+          curl ${{ secrets.TF_ENDPOINT }}/requests --data @request.json --header "Content-Type: application/json" --output response.json
+          # Store REQ_ID into outputs for later on usage
+          echo "::set-output name=REQ_ID::$(jq -r .id response.json)"
+
+  running:
+    needs: build
+    name: Check running tests on Testing Farm service
+    runs-on: ubuntu-20.04
+    outputs:
+      REQ_ID: ${{steps.req_sha.outputs.REQ_ID}}
+      SHA: ${{steps.req_sha.outputs.SHA}}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check if REQ_ID and SHA exists
+        id: req_sha
+        run: |
+          # Update ubuntu-20.04 in order to install curl and jq
+          # each job is separate machine
+          apt update && apt -y install curl jq
+          # Propagate REQ_ID and SHA into the finish section
+          echo "::set-output name=REQ_ID::${{needs.build.outputs.REQ_ID}}"
+          echo "::set-output name=SHA::${{needs.build.outputs.SHA}}"
+
+      - name: Switch to running state of Testing Farm request
+        id: running
+        run: |
+          # Create running.json file for query, whether job is finished or not.
+          cat << EOF > running.json
+          {
+            "sha": "${{needs.build.outputs.SHA}}",
+            "state": "pending",
+            "context": "Testing Farm",
+            "description": "Build started",
+            "target_url": "http://artifacts.dev.testing-farm.io/${{ needs.build.outputs.REQ_ID }}/"
+          }
+          EOF
+          # Update GitHub status description to 'Build started'
+          curl -X POST -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{needs.build.outputs.SHA}} \
+            --data @running.json
+
+      - name: Check test is still running
+        id: still_running
+        run: |
+          CMD=${{ secrets.TF_ENDPOINT }}/requests/${{needs.build.outputs.REQ_ID}}
+          curl $CMD > job.json
+          state=$(jq -r .state job.json)
+          # Wait till job is not finished. As soon as state is complete or failure then go to the finish action
+          while [ "$state" == "running" ] || [ "$state" == "new" ] || [ "$state" == "pending" ] || [ "$state" == "queued" ]; do
+            # Wait 30s. We do not need to query Testing Farm each second
+            sleep 30
+            curl $CMD > job.json
+            state=$(jq -r .state job.json)
+          done
+
+  finish:
+    needs: running
+    name: Tests are finished - switching to proper state
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check if REQ_ID exists
+        run: echo "${{ needs.running.outputs.REQ_ID }}"
+
+      - name: Check if SHA exists
+        run: echo "${{ needs.running.outputs.SHA }}"
+
+      - name: Get final state of Testing Farm request
+        id: final_state
+        run: |
+          # Update ubuntu-20.04 in order to install curl and jq
+          # each job is separate machine
+          apt update && apt -y install curl jq
+          curl ${{ secrets.TF_ENDPOINT }}/requests/${{needs.running.outputs.REQ_ID}} > job.json
+          cat job.json
+          state=$(jq -r .state job.json)
+          result=$(jq -r .result.overall job.json)
+          new_state="success"
+          infra_error=" "
+          echo "State is $state and result is: $result"
+          if [ "$state" == "complete" ]; then
+            if [ "$result" != "passed" ]; then
+              new_state="failure"
+            fi
+          else
+            # Mark job in case of infrastructure issues. Report to Testing Farm team
+            infra_error=" - Infra problems"
+            new_state="failure"
+          fi
+          echo "New State is: $new_state"
+          echo "Infra state is: $infra_error"
+          echo "::set-output name=FINAL_STATE::$new_state"
+          echo "::set-output name=INFRA_STATE::$infra_error"
+
+      - name: Switch to final state of Testing Farm request
+        run: |
+          cat << EOF > final.json
+          {
+            "sha": "${{needs.running.outputs.SHA}}",
+            "state": "${{steps.final_state.outputs.FINAL_STATE}}",
+            "context": "Testing Farm",
+            "description": "Build finished${{steps.final_state.outputs.INFRA_STATE}}",
+            "target_url": "http://artifacts.dev.testing-farm.io/${{ needs.running.outputs.REQ_ID }}/"
+          }
+          EOF
+          cat final.json
+          # Switch Github status to proper state
+          curl -X POST -H "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{needs.running.outputs.SHA}} \
+            --data @final.json

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -9,13 +9,10 @@ jobs:
     # This job only runs for '[test]' pull request comments by owner, member
     name: Schedule test on Testing Farm service for Fedora
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: [py36, py37, py38, py39]
     if: |
       github.event.issue.pull_request
       && contains(github.event.comment.body, '/test')
-      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
+      && contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association)
     outputs:
       REQ_ID: ${{steps.sched_test.outputs.REQ_ID}}
       SHA: ${{steps.sha.outputs.SHA}}
@@ -37,33 +34,11 @@ jobs:
           # Store SHA into outputs
           echo "::set-output name=SHA::$(git rev-parse HEAD)"
 
-      - name: Create status check to pending
-        id: pending
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Create a JSON file for Testing Farm in order to schedule a CI testing job
-          cat << EOF > pending.json
-          {
-            "sha": "${{steps.sha.outputs.SHA}}",
-            "state": "pending",
-            "context": "Testing Farm",
-            "target_url": "http://artifacts.dev.testing-farm.io/${{ steps.sched_test.outputs.req_id }}/pipeline.log"
-          }
-          EOF
-          echo "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{steps.sha.outputs.SHA}}"
-          # GITHUB_TOKEN is used for updating pull request status.
-          # It is provided by GitHub https://docs.github.com/en/actions/reference/authentication-in-a-workflow#about-the-github_token-secret
-          curl -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{steps.sha.outputs.SHA}} \
-            --data @pending.json
-          echo "::set-output name=GITHUB_REPOSITORY::$GITHUB_REPOSITORY"
-
       - name: Schedule a test on Testing Farm for Fedora
         id: sched_test
         run: |
           # Update ubuntu-latest in order to install curl and jq
-          apt update && apt -y install curl jq
+          sudo apt-get update && sudo apt-get -y install curl jq
           cat << EOF > request.json
           {
             "api_key": "${{ secrets.TF_PUBLIC_API_KEY }}",
@@ -79,22 +54,46 @@ jobs:
                 "REPO_URL": "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY",
                 "REPO_NAME": "$GITHUB_REPOSITORY",
                 "PR_NUMBER": "${{ steps.pr_nr.outputs.PR_NR }}",
-                "TOX": "${{ matrix.python }}",
               }
             }]
           }
           EOF
           curl ${{ secrets.TF_ENDPOINT }}/requests --data @request.json --header "Content-Type: application/json" --output response.json
+          cat response.json
+          req_id=$(jq -r .id response.json)
+
           # Store REQ_ID into outputs for later on usage
-          echo "::set-output name=REQ_ID::$(jq -r .id response.json)"
+          echo "::set-output name=REQ_ID::$req_id"
+
+      - name: Create status check to pending
+        id: pending
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Create a JSON file for Testing Farm in order to schedule a CI testing job
+          cat << EOF > pending.json
+          {
+            "sha": "${{steps.sha.outputs.SHA}}",
+            "state": "pending",
+            "context": "Testing Farm",
+            "target_url": "http://artifacts.dev.testing-farm.io/${{ steps.sched_test.outputs.req_id }}/pipeline.log"
+          }
+          EOF
+          echo "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{ steps.sha.outputs.SHA }}"
+          # GITHUB_TOKEN is used for updating pull request status.
+          # It is provided by GitHub https://docs.github.com/en/actions/reference/authentication-in-a-workflow#about-the-github_token-secret
+          curl -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{ steps.sha.outputs.SHA }} \
+            --data @pending.json
+          echo "::set-output name=GITHUB_REPOSITORY::$GITHUB_REPOSITORY"
 
   running:
     needs: build
     name: Check running tests on Testing Farm service
     runs-on: ubuntu-20.04
     outputs:
-      REQ_ID: ${{steps.req_sha.outputs.REQ_ID}}
-      SHA: ${{steps.req_sha.outputs.SHA}}
+      REQ_ID: ${{ steps.req_sha.outputs.REQ_ID }}
+      SHA: ${{ steps.req_sha.outputs.SHA }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check if REQ_ID and SHA exists
@@ -102,10 +101,10 @@ jobs:
         run: |
           # Update ubuntu-20.04 in order to install curl and jq
           # each job is separate machine
-          apt update && apt -y install curl jq
+          sudo apt-get update && sudo apt-get -y install curl jq
           # Propagate REQ_ID and SHA into the finish section
-          echo "::set-output name=REQ_ID::${{needs.build.outputs.REQ_ID}}"
-          echo "::set-output name=SHA::${{needs.build.outputs.SHA}}"
+          echo "::set-output name=REQ_ID::${{ needs.build.outputs.REQ_ID }}"
+          echo "::set-output name=SHA::${{ needs.build.outputs.SHA }}"
 
       - name: Switch to running state of Testing Farm request
         id: running
@@ -113,7 +112,7 @@ jobs:
           # Create running.json file for query, whether job is finished or not.
           cat << EOF > running.json
           {
-            "sha": "${{needs.build.outputs.SHA}}",
+            "sha": "${{ needs.build.outputs.SHA }}",
             "state": "pending",
             "context": "Testing Farm",
             "description": "Build started",
@@ -122,13 +121,13 @@ jobs:
           EOF
           # Update GitHub status description to 'Build started'
           curl -X POST -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{needs.build.outputs.SHA}} \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{ needs.build.outputs.SHA }} \
             --data @running.json
 
       - name: Check test is still running
         id: still_running
         run: |
-          CMD=${{ secrets.TF_ENDPOINT }}/requests/${{needs.build.outputs.REQ_ID}}
+          CMD=${{ secrets.TF_ENDPOINT }}/requests/${{ needs.build.outputs.REQ_ID }}
           curl $CMD > job.json
           state=$(jq -r .state job.json)
           # Wait till job is not finished. As soon as state is complete or failure then go to the finish action
@@ -155,8 +154,8 @@ jobs:
         run: |
           # Update ubuntu-20.04 in order to install curl and jq
           # each job is separate machine
-          apt update && apt -y install curl jq
-          curl ${{ secrets.TF_ENDPOINT }}/requests/${{needs.running.outputs.REQ_ID}} > job.json
+          sudo apt-get update && sudo apt-get -y install curl jq
+          curl ${{ secrets.TF_ENDPOINT }}/requests/${{ needs.running.outputs.REQ_ID }} > job.json
           cat job.json
           state=$(jq -r .state job.json)
           result=$(jq -r .result.overall job.json)
@@ -191,5 +190,5 @@ jobs:
           cat final.json
           # Switch Github status to proper state
           curl -X POST -H "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{needs.running.outputs.SHA}} \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{ needs.running.outputs.SHA }} \
             --data @final.json


### PR DESCRIPTION
This pull request adds support for enabling tests in Testing Farm.
TMT/FMF format is taken from https://github.com/sclorg/sclorg-testing-farm repository.
Especially this https://github.com/sclorg/sclorg-testing-farm/blob/main/plans/cwt.fmf.

What to review?
- The tests are executed by '/test' comment. https://github.com/sclorg/container-workflow-tool/compare/master...phracek:testing_farm?expand=1#diff-3916175353da81b6cca987b01c9e9615428e7601e00c805533c7844c1528658fR17
- For tests, we are using the Fedora-34 system.
- Only the default Python version is supported but will be added more versions.
- The message shown in PR status is: Testing Farm, for now, later it will be Python version.

If you do not see anything critical, we can merge it and test it.

As an example, you can see results here:
http://artifacts.dev.testing-farm.io/396c7ce9-fa14-4119-8982-f35385aac286/

 for PR 38.
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>