### PR TITLE
remove dockerhub functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Requirements
 * python3-GitPython
 * python3-requests-kerberos
 * fedpkg
-* http://github.com/ficap/dhwebapi (installed using pip3 and requirements.txt)
 
 Options
 -------
@@ -33,7 +32,6 @@ usage: cwt [options] command
     Command:
         koji            - List builds, base images, hash ids
         build           - Command for building images
-        dockerhub       - Manipulate DockerHub repo/registry
         git             - Work with upstream/downstream git repositories
         utils           - Other actions tied to the rebuild (communication, repository preparation etc.)
 

--- a/container_workflow_tool/cli_common.py
+++ b/container_workflow_tool/cli_common.py
@@ -69,7 +69,6 @@ class CliCommon(object):
     Command:
         {cmd}
         build           - Command for building images
-        dockerhub       - Manipulate DockerHub repo/registry
         git             - Work with upstream/downstream git repositories
         utils           - Other actions tied to the rebuild (communication, repository preparation etc.)
 
@@ -116,13 +115,6 @@ class CliCommon(object):
         latestbuilds - Query koji and list latest builds of images
     """
         return action_help
-
-    def dockerhub_usage(self):
-        action_help = """%s dockerhub action
-    Action:
-        updatefulldescription - Update full description on DockerHub
-        """
-        return action_help % self.prg_name
 
     def build_usage(self):
         action_help = """%s build image_set

--- a/container_workflow_tool/constants.py
+++ b/container_workflow_tool/constants.py
@@ -14,10 +14,6 @@ action_map['koji'] = {
     'latestbuilds': 'print_brew_builds',
 }
 
-action_map['dockerhub'] = {
-    'updatefulldescription': 'update_dh_description',
-}
-
 action_map['utils'] = {
     'showconfig': 'show_config_contents',
     'listimages': 'list_images',
@@ -33,7 +29,6 @@ actions = {}
 actions['git'] = ['pullupstream', 'clonedownstream', 'cloneupstream',
                   'rebase', 'merge', 'show', 'push', ]
 actions['koji'] = ['latestbuilds', ]
-actions['dockerhub'] = ['updatefulldescription', ]
 actions['utils'] = ['showconfig', 'listimages', 'listupstream', ]
 
 COMMAND = ""

--- a/container_workflow_tool/decorators.py
+++ b/container_workflow_tool/decorators.py
@@ -27,10 +27,3 @@ def needs_brewapi(f):
         self._setup_brewapi()
         return f(self, *args, **kwargs)
     return wrapper
-
-
-def needs_dhapi(f):
-    def wrapper(self, *args, **kwargs):
-        self._setup_dhapi()
-        return f(self, *args, **kwargs)
-    return wrapper

--- a/man/cwt.1
+++ b/man/cwt.1
@@ -14,9 +14,6 @@ cwt \- A python3 tool to make rebuilding Docker images easier by automating seve
 \fIbuild\/\fR
 
 .B cwt
-\fIdockerhub\/\fR
-
-.B cwt
 \fIgit\/\fR
 
 .B cwt
@@ -32,9 +29,6 @@ cwt \- A python3 tool to make rebuilding Docker images easier by automating seve
 
 .PP
 \fIbuild\/\fR It builds images.
-
-.PP
-\fIdockerbug\/\fR It manipulates with DockerHub repo/registry.
 
 .PP
 \fIgit\/\fR It works with upstream/downstream git repositories.


### PR DESCRIPTION
This PR removes the dockerhub interface from the container-workflow-tool.

With this removal also one dependency is removed - dhwebapi library.