### PR TITLE
Adding github workflow for releasing the cwt in PyPI

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,9 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018 Userspace Containerization team at Red Hat
-#
-# source of this file is at:
-# https://github.com/packit/packit/blob/main/.github/workflows/pypi-publish.yml
+# Copyright (c) 2018 sclorg team at Red Hat
 #
 # Upload a Python package when a release is created
 # https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows


### PR DESCRIPTION
The original source of the file is at:
https://github.com/packit/packit

I am not sure, if the MIT licence and source of the file is listed correctly, please correct me, if it is not.

The PR was tested locally with `act` tool, however the actual dist release to PyPI was not tested yet.
As this github action is being run only on release, the cwt release is (IMHO) the only option how to test it.