### PR TITLE
fix of missing conf files in cwt installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
     url='https://github.com/sclorg/container-workflow-tool',
     license='MIT',
     packages=find_packages(exclude=['man', 'tests']),
+    include_package_data=True,
     scripts=[],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Hello,

I am sorry, but with https://github.com/sclorg/container-workflow-tool/pull/43/commits/aae4a275d979f52f0562a2daf53aefa2897454e7 I introduced installation error - the .yaml configs were not exported to the package.
This PR fixes the error.
