### PR TITLE
property base_image is not needed

### DIFF
--- a/container_workflow_tool/main.py
+++ b/container_workflow_tool/main.py
@@ -39,7 +39,7 @@ class ImageRebuilder:
             rebuild_reason (str, optional): reason for the rebuild,
                                             used in commit
         """
-        self._base_image = base_image
+        self.base_image = base_image
 
         self._brewapi: KojiAPI = None
         self._distgit: DistgitAPI = None
@@ -149,12 +149,6 @@ class ImageRebuilder:
             self._brewapi = KojiAPI(self.conf, self.logger.getChild("koji"),
                                    self.latest_release)
         return self._brewapi
-
-    @property
-    def base_image(self):
-        if not self._base_image:
-            raise RebuilderError("Base image needs to be set.")
-        return self._base_image
 
     def _setup_logger(self, level=logging.INFO, user_logger=None, name=__name__):
         # If a logger is already set up, do not setup a new one


### PR DESCRIPTION
property base_image means, that if it is not used,
like in case utils setup repo, then it needs to be set.

This is bug

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>