### PR TITLE
Fix base_image error traceback and add test suite for relevant functions

### DIFF
--- a/container_workflow_tool/main.py
+++ b/container_workflow_tool/main.py
@@ -174,6 +174,7 @@ class ImageRebuilder:
         os.chdir(path)
 
     def _get_tmp_workdir(self, setup_dir: bool = True) -> str:
+        self._check_base(self.base_image)
         # Check if the workdir has been set by the user
         if self.tmp_workdir:
             return self.tmp_workdir
@@ -197,6 +198,10 @@ class ImageRebuilder:
 
     def set_do_set(self, val):
         self.do_set = val
+
+    def _check_base(self, base_image):
+        if not base_image:
+            raise RebuilderError("Base image needs to be set.")
 
     def _get_images(self) -> List:
         images: List = []

--- a/tests/test_rebuilder.py
+++ b/tests/test_rebuilder.py
@@ -86,6 +86,51 @@ class TestRebuilder(object):
         assert self.ir.repo_url == url
 
 
+class TestRebuilderNoBaseImage(object):
+
+    def setup_method(self):
+        self.component = 's2i-base'
+        self.ir = ImageRebuilder('Testing')
+        self.ir.base_image = None
+        self.ir.set_config('default.yaml', release="rawhide")
+        # Partner BZ testing
+        self.ir.rebuild_reason = "Unit testing"
+        self.ir.disable_klist = True
+        self.ir.set_do_images([self.component])
+
+    def test_distgit_pull_upstream(self):
+        with pytest.raises(RebuilderError):
+            self.ir.pull_downstream()
+
+    def test_prebuild_check(self):
+        with pytest.raises(RebuilderError):
+            self.ir._prebuild_check([self.component])
+
+    def test_main_build_images(self):
+        with pytest.raises(RebuilderError):
+            self.ir._build_images([self.component], branches=["rawhide"])
+
+    def test_main_pull_downstream(self):
+        with pytest.raises(RebuilderError):
+            self.ir.pull_downstream()
+
+    def test_main_pull_upstream(self):
+        with pytest.raises(RebuilderError):
+            self.ir.pull_upstream()
+
+    def test_main_push_changes(self):
+        with pytest.raises(RebuilderError):
+            self.ir.push_changes()
+
+    def test_main_merge_future_branches(self):
+        with pytest.raises(RebuilderError):
+            self.ir.merge_future_branches()
+
+    def test_main_show_git_changes(self):
+        with pytest.raises(RebuilderError):
+            self.ir.show_git_changes()
+
+
 class TestRebuilderNoSetupDir(object):
 
     def setup_method(self):


### PR DESCRIPTION
Thanks @pkubatrh catching this error. (http://pastebin.test.redhat.com/1071317) It was my mistake and the tests were completely missing.

Now the tests are covered. Each function that needs base_image is checked.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>