### PR TITLE
During test-openshift.yaml update use double quotes

### DIFF
--- a/container_workflow_tool/distgit.py
+++ b/container_workflow_tool/distgit.py
@@ -78,7 +78,7 @@ class DistgitAPI(object):
         It replaces OS: OS_VERSION -> OS: <os_name>"
         """
         self.logger.debug(f"Replaces variable of tag {tag} from {tag_str} to {variable}")
-        ret = re.sub(rf"{tag}: {tag_str}", f"{tag}: {variable}", fdata)
+        ret = re.sub(rf'{tag}: "{tag_str}"', f"{tag}: \"{variable}\"", fdata)
         return ret
 
     def _update_test_openshift_yaml(self, test_openshift_yaml, version: str = "", short_name: str = ""):

--- a/tests/data/test-openshift.yaml
+++ b/tests/data/test-openshift.yaml
@@ -5,9 +5,9 @@
     - openshift
 
   environment:
-    VERSION: VERSION_NUMBER
-    OS: OS_NUMBER
-    SHORT_NAME: CONTAINER_NAME
+    VERSION: "VERSION_NUMBER"
+    OS: "OS_NUMBER"
+    SHORT_NAME: "CONTAINER_NAME"
     IMAGE_FULL_NAME: "{{ image_full_name }}"
     IMAGE_REGISTRY_URL: "{{ image_registry_url }}"
     IMAGE_NAMESPACE: "{{ image_namespace }}"

--- a/tests/test_distgit.py
+++ b/tests/test_distgit.py
@@ -134,7 +134,7 @@ class TestDistgit(object):
         with open(os.path.join(DATA_DIR, "test-openshift.yaml")) as f:
             yaml_file = f.read()
         fixed = self.ir.distgit._update_variable_in_string(fdata=yaml_file, tag=tag, tag_str=tag_str, variable=variable)
-        result = f"{tag}: {variable}" in fixed
+        result = f"{tag}: \"{variable}\"" in fixed
         assert result == expected
 
     @pytest.mark.parametrize(
@@ -155,5 +155,5 @@ class TestDistgit(object):
         self.ir.distgit._update_test_openshift_yaml(str(target_name), version=version)
         with open(target_name) as f:
             content = f.read()
-        assert f"VERSION: {version}" in content
-        assert f"OS: {os_name_expected}" in content
+        assert f"VERSION: \"{version}\"" in content
+        assert f"OS: \"{os_name_expected}\"" in content


### PR DESCRIPTION
In case of version is specified like `VERSION: 1.20` then during CVP pipeline in ansible-playbook
version used in testing is `1.2`. Number `0` is deleted because it is converted to a number.

The VERSION has to be used as text like `VERSION: "1.20"` which is used in ansible-playbook.
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>