### PR TITLE
Use GitLab for syncing upstream->downstream - gitlab_git_changes

### DIFF
--- a/container_workflow_tool/cli_common.py
+++ b/container_workflow_tool/cli_common.py
@@ -59,10 +59,6 @@ class CliCommon(object):
         parsers['git'].add_argument('--rebuild-reason', help='Use a custom reason for rebuilding')
         parsers['git'].add_argument('--commit-msg', help='Use a custom message instead of the default one')
         parsers['git'].add_argument('--check-script', help='Script/command to be run when checking repositories')
-        parsers['git'].add_argument(
-            '--gitlab', action='store_true', default=False,
-            help='File a merge request to corresponding repository instead of directly to dist-git'
-        )
         parsers['build'].add_argument(
             '--repo-url', help='Set the url of a .repo file to be used when building the image'
         )
@@ -110,7 +106,6 @@ class CliCommon(object):
         --commit-msg     - Use a custom message instead of the default one
         --rebuild-reason - Use a custom reason for rebuilding
         --check-script   - Script/command to be run when checking repositories
-        --gitlab         - Use GitLab for filling merge requests instead of direct pushing to dist-git
     """
         return action_help
 

--- a/container_workflow_tool/cli_common.py
+++ b/container_workflow_tool/cli_common.py
@@ -59,6 +59,10 @@ class CliCommon(object):
         parsers['git'].add_argument('--rebuild-reason', help='Use a custom reason for rebuilding')
         parsers['git'].add_argument('--commit-msg', help='Use a custom message instead of the default one')
         parsers['git'].add_argument('--check-script', help='Script/command to be run when checking repositories')
+        parsers['git'].add_argument(
+            '--gitlab', action='store_true', default=False,
+            help='File a merge request to corresponding repository instead of directly to dist-git'
+        )
         parsers['build'].add_argument(
             '--repo-url', help='Set the url of a .repo file to be used when building the image'
         )
@@ -106,6 +110,7 @@ class CliCommon(object):
         --commit-msg     - Use a custom message instead of the default one
         --rebuild-reason - Use a custom reason for rebuilding
         --check-script   - Script/command to be run when checking repositories
+        --gitlab         - Use GitLab for filling merge requests instead of direct pushing to dist-git
     """
         return action_help
 

--- a/container_workflow_tool/constants.py
+++ b/container_workflow_tool/constants.py
@@ -1,6 +1,6 @@
 action_map = {}
 action_map['git'] = {
-    'pullupstream': 'dist_git_changes',
+    'pullupstream': 'dist_git_merge_changes',
     'clonedownstream': 'pull_downstream',
     'cloneupstream': 'pull_upstream',
     'rebase': 'dist_git_rebase',

--- a/container_workflow_tool/distgit.py
+++ b/container_workflow_tool/distgit.py
@@ -60,6 +60,7 @@ class DistgitAPI(GitOperations):
         Merge is done by copying tracked files from upstream into downstream.
 
         Args:
+            images (list): List of images to sync
             rebase (bool, optional): Specify if a rebase should be done instead
         """
         try:

--- a/container_workflow_tool/distgit.py
+++ b/container_workflow_tool/distgit.py
@@ -53,7 +53,7 @@ class DistgitAPI(GitOperations):
         else:
             self.logger.info(template.format(name=component, status="OK"))
 
-    def dist_git_changes(self, images, rebase=False):
+    def dist_git_merge_changes(self, images, rebase=False):
         """Method to merge changes from upstream into downstream
 
         Pulls both downstream and upstream repositories into a temporary dir.

--- a/container_workflow_tool/distgit.py
+++ b/container_workflow_tool/distgit.py
@@ -5,7 +5,7 @@ import subprocess
 from git import Repo
 from git.exc import GitCommandError
 
-import container_workflow_tool.utility as u
+from container_workflow_tool import utility
 from container_workflow_tool.utility import RebuilderError
 from container_workflow_tool.dockerfile import DockerfileHandler
 from container_workflow_tool.sync import SyncHandler
@@ -49,7 +49,7 @@ class DistgitAPI(GitOperations):
             self.logger.info(template.format(name=component, status="Affected"))
             err = ret.stderr.decode('utf-8').strip()
             if err:
-                self.logger.error(u._2sp(err))
+                self.logger.error(utility._2sp(err))
         else:
             self.logger.info(template.format(name=component, status="OK"))
 
@@ -63,7 +63,7 @@ class DistgitAPI(GitOperations):
             rebase (bool, optional): Specify if a rebase should be done instead
         """
         try:
-            for image in (images):
+            for image in images:
                 name = image["name"]
                 component = image["component"]
                 branch = image["git_branch"]
@@ -92,18 +92,17 @@ class DistgitAPI(GitOperations):
                     ups_name = name.split('-')[0]
                     # Clone upstream repository
                     ups_path = os.path.join('upstreams/', ups_name)
-                    self._clone_upstream(url, ups_path, commands=commands)
+                    self.clone_upstream(url, ups_path, commands=commands)
                     # Save the upstream commit hash
                     ups_hash = Repo(ups_path).commit().hexsha
-                    self._pull_upstream(component, path, url, repo, ups_name, commands)
+                    self.pull_upstream(component, path, url, repo, ups_name, commands)
                     self.df_handler.update_dockerfile(
                         df_path, from_tag, downstream_from=downstream_from
                     )
                     repo.git.add("Dockerfile")
                     # It is possible for the git repository to have no changes
                     if repo.is_dirty():
-                        commit = self.get_commit_msg(rebase, image, ups_hash
-                        )
+                        commit = self.get_commit_msg(rebase, image, ups_hash)
                         if commit:
                             repo.git.commit("-m", commit)
                         else:
@@ -122,8 +121,8 @@ class DistgitAPI(GitOperations):
             self.logger.info("Using existing downstream repo: " + component)
             repo = Repo(component)
         else:
-            hostname_url = u._get_hostname_url(self.conf)
-            packager = u._get_packager(self.conf)
+            hostname_url = utility._get_hostname_url(self.conf)
+            packager = utility._get_packager(self.conf)
             # if packager is fedpkg then namespace is `container` else `containers`
             namespace = "container" if packager == "fedpkg" else "containers"
             component_path = f"{namespace}/{component}"
@@ -162,7 +161,7 @@ class DistgitAPI(GitOperations):
                     # commit_msg is set so it is always returned
                     commit = self.get_commit_msg(None, image)
                     repo.git.commit("-am", commit)
-                if self._get_unpushed_commits(repo):
+                if self.are_unpushed_commits_available(repo):
                     self.logger.info("Pushing: " + component)
 
                     repo.git.push()
@@ -176,7 +175,7 @@ class DistgitAPI(GitOperations):
         if failed:
             self.logger.error("Failed pushing images:")
             for image in failed:
-                self.logger.error(u._2sp(image["component"]))
+                self.logger.error(utility._2sp(image["component"]))
             self.logger.error("Please check the failures and push the changes manually.")
 
     # TODO: Multiple future branches?
@@ -204,5 +203,5 @@ class DistgitAPI(GitOperations):
         if failed:
             self.logger.error("Failed merging images:")
             for image in failed:
-                self.logger.error(u._2sp(image["component"]))
+                self.logger.error(utility._2sp(image["component"]))
             self.logger.error("Please check the failures and push the changes manually.")

--- a/container_workflow_tool/git_operations.py
+++ b/container_workflow_tool/git_operations.py
@@ -126,7 +126,7 @@ class GitOperations(object):
         select = "origin/" + branch + ".." + branch
         if branch_name != "":
             select = "origin/" + branch_name + ".." + branch
-        if len(list(repo.iter_commits(select))) == 0:
+        return bool(list(repo.iter_commits(select)))
             return False
         return True
 

--- a/container_workflow_tool/git_operations.py
+++ b/container_workflow_tool/git_operations.py
@@ -117,7 +117,8 @@ class GitOperations(object):
         """
         Get unpushed commits
         :param repo: repo object to check for unpushed commits
-        :param branch_name: In case of gitlab, forked_branch and branch_name has to be defined.
+        :param branch_name: In case of gitlab, branch_name has to be defined.
+        :param branch_name: In case of gitlab, branch_name has to be defined.
                             branch_name is e.g. rhel-8.7.0 and 'repo.active_branch.name' is 'rhel-8.7.0-<ubi_name>'
         :return: List of commits or empty array
         """
@@ -137,7 +138,7 @@ class GitOperations(object):
             tmp (str): Path to the directory that is used to store git repositories
             components (list of str, optional): List of components to show changes for
             diff (boolean, optional): Controls whether the method calls git-show or git-diff
-            branch_name (str, optional): In case of gitlab, forked_branch and branch_name has to be defined.
+            branch_name (str, optional): In case of gitlab, branch_name has to be defined.
                             branch_name is e.g. rhel-8.7.0 and 'repo.active_branch.name' is 'rhel-8.7.0-<ubi_name>'
         """
         # Function to check if a path contains a git repository

--- a/container_workflow_tool/git_operations.py
+++ b/container_workflow_tool/git_operations.py
@@ -127,8 +127,6 @@ class GitOperations(object):
         if branch_name != "":
             select = "origin/" + branch_name + ".." + branch
         return bool(list(repo.iter_commits(select)))
-            return False
-        return True
 
     def show_git_changes(self, tmp, components=None, diff=False, branch_name=""):
         """Shows changes made to tracked files in local downstream repositories

--- a/container_workflow_tool/main.py
+++ b/container_workflow_tool/main.py
@@ -117,8 +117,6 @@ class ImageRebuilder:
             self.set_commit_msg(args.commit_msg)
         if getattr(args, 'rebuild_reason', None) is not None and args.rebuild_reason:
             self.rebuild_reason = args.rebuild_reason
-        if args.command == "git":
-            self.gitlab_usage = args.gitlab
         if getattr(args, 'check_script', None) is not None and args.check_script:
             self.check_script = args.check_script
         self.disable_klist = args.disable_klist

--- a/container_workflow_tool/main.py
+++ b/container_workflow_tool/main.py
@@ -552,7 +552,7 @@ class ImageRebuilder:
         Do a rebase against a new base/s2i image.
         Does not pull in upstream changes of layered images.
         """
-        self.dist_git_changes(rebase=True)
+        self.dist_git_merge_changes(rebase=True)
 
     def git_changes_report(self, tmp):
         self.logger.info("\nGit location: " + tmp)
@@ -566,7 +566,7 @@ class ImageRebuilder:
                 "cwt git push && cwt build"
                 "[base/core/s2i] --repo-url link-to-repo-file")
 
-    def dist_git_changes(self, rebase: bool = False):
+    def dist_git_merge_changes(self, rebase: bool = False):
         """Method to merge changes from upstream into downstream
 
         Pulls both downstream and upstream repositories into a temporary directory.
@@ -576,7 +576,7 @@ class ImageRebuilder:
             rebase (bool, optional): Specifies whether a rebase should be done instead.
         """
         tmp, images = self.preparation()
-        self.distgit.dist_git_changes(images, rebase)
+        self.distgit.dist_git_merge_changes(images, rebase)
         self.git_changes_report(tmp=tmp)
 
     def merge_future_branches(self):

--- a/container_workflow_tool/utility.py
+++ b/container_workflow_tool/utility.py
@@ -2,8 +2,9 @@ import sys
 import argparse
 import os
 import logging
-
+from pathlib import Path
 import textwrap
+import contextlib
 
 
 class RebuilderError(Exception):
@@ -71,6 +72,22 @@ def _split_config_path(config: str):
     config_path = conf[0]
     image_set = conf[1] if len(conf) > 1 else 'current'
     return config_path, image_set
+
+
+@contextlib.contextmanager
+def cwd(path):
+    """
+    Checks out a git repository into a temporary directory.
+    Changes CWD to the temporary directory.
+    Yields the temporary directory.
+    On exit, the temporary directory is removed and CWD is restored.
+    """
+    prev_cwd = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(prev_cwd)
 
 
 def setup_logger(logger_id, level=logging.INFO):

--- a/container_workflow_tool/utility.py
+++ b/container_workflow_tool/utility.py
@@ -77,10 +77,8 @@ def _split_config_path(config: str):
 @contextlib.contextmanager
 def cwd(path):
     """
-    Checks out a git repository into a temporary directory.
     Changes CWD to the temporary directory.
     Yields the temporary directory.
-    On exit, the temporary directory is removed and CWD is restored.
     """
     prev_cwd = Path.cwd()
     os.chdir(path)

--- a/image-requirements/install-requirements.yaml
+++ b/image-requirements/install-requirements.yaml
@@ -13,4 +13,5 @@
           - krb5-devel
           - krb5-workstation
           - golang-github-cpuguy83-md2man
+          - python3-gitlab
       become: true

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def get_dir(system_path=None, virtual_path=None):
 
 setup(
     name='container-workflow-tool',
-    version="1.5.3",
+    version="1.5.4",
     description='A python3 tool to make rebuilding images easier by automating several steps of the process.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/data/nodejs-16/Dockerfile
+++ b/tests/data/nodejs-16/Dockerfile
@@ -1,0 +1,103 @@
+FROM rhscl/s2i-core-rhel7:1
+
+# RHSCL rh-nginx116 image.
+#
+# Volumes:
+#  * /var/opt/rh/rh-nginx116/log/nginx/ - Storage for logs
+
+EXPOSE 8080
+EXPOSE 8443
+
+ENV NAME=nginx \
+    NGINX_VERSION=1.16 \
+    NGINX_SHORT_VER=116 \
+    PERL_SCL_SHORT_VER=526 \
+    VERSION=0
+
+# Set SCL related variables in Dockerfile so that the collection is enabled by default
+ENV SUMMARY="Platform for running nginx $NGINX_VERSION or building nginx-based application" \
+    DESCRIPTION="Nginx is a web server and a reverse proxy server for HTTP, SMTP, POP3 and IMAP \
+protocols, with a strong focus on high concurrency, performance and low memory usage. The container \
+image provides a containerized packaging of the nginx $NGINX_VERSION daemon. The image can be used \
+as a base image for other applications based on nginx $NGINX_VERSION web server. \
+Nginx server image can be extended using source-to-image tool." \
+    X_SCLS="rh-perl$PERL_SCL_SHORT_VER rh-nginx$NGINX_SHORT_VER" \
+    PATH=/opt/rh/rh-perl$PERL_SCL_SHORT_VER/root/usr/local/bin:/opt/rh/rh-perl$PERL_SCL_SHORT_VER/root/usr/bin:/opt/rh/rh-nginx$NGINX_SHORT_VER/root/usr/bin:/opt/rh/rh-nginx$NGINX_SHORT_VER/root/usr/sbin${PATH:+:${PATH}} \
+    MANPATH=/opt/rh/rh-perl$PERL_SCL_SHORT_VER/root/usr/share/man:/opt/rh/rh-nginx$NGINX_SHORT_VER/root/usr/share/man:${MANPATH} \
+    PKG_CONFIG_PATH=/opt/rh/rh-nginx$NGINX_SHORT_VER/root/usr/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}} \
+    LD_LIBRARY_PATH=/opt/rh/rh-perl$PERL_SCL_SHORT_VER/root/usr/lib64 \
+    PERL5LIB="/opt/rh/rh-nginx$NGINX_SHORT_VER/root/usr/lib64/perl5/vendor_perl${PERL5LIB:+:${PERL5LIB}}"
+
+LABEL summary="${SUMMARY}" \
+      description="${DESCRIPTION}" \
+      io.k8s.description="${DESCRIPTION}" \
+      io.k8s.display-name="Nginx ${NGINX_VERSION}" \
+      io.openshift.expose-services="8080:http" \
+      io.openshift.expose-services="8443:https" \
+      io.openshift.tags="builder,${NAME},rh-${NAME}${NGINX_SHORT_VER}" \
+      com.redhat.component="rh-${NAME}${NGINX_SHORT_VER}-container" \
+      name="rhscl/${NAME}-${NGINX_SHORT_VER}-rhel7" \
+      version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
+      help="For more information visit https://github.com/sclorg/${NAME}-container" \
+      usage="s2i build <SOURCE-REPOSITORY> rhscl/${NAME}-${NGINX_SHORT_VER}-rhel7:latest <APP-NAME>"
+
+ENV NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
+    NGINX_CONF_PATH=/etc/opt/rh/rh-nginx${NGINX_SHORT_VER}/nginx/nginx.conf \
+    NGINX_DEFAULT_CONF_PATH=${APP_ROOT}/etc/nginx.default.d \
+    NGINX_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nginx \
+    NGINX_APP_ROOT=${APP_ROOT} \
+    NGINX_LOG_PATH=/var/opt/rh/rh-nginx${NGINX_SHORT_VER}/log/nginx \
+    NGINX_PERL_MODULE_PATH=${APP_ROOT}/etc/perl
+
+RUN yum install -y yum-utils && \
+    prepare-yum-repositories rhel-server-rhscl-7-rpms && \
+    INSTALL_PKGS="nss_wrapper bind-utils gettext hostname rh-nginx${NGINX_SHORT_VER} rh-nginx${NGINX_SHORT_VER}-nginx \
+                  rh-nginx${NGINX_SHORT_VER}-nginx-mod-stream rh-nginx${NGINX_SHORT_VER}-nginx-mod-http-perl" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum -y clean all --enablerepo='*'
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+# In order to drop the root user, we have to make some directories world
+# writeable as OpenShift default security model is to run the container under
+# random UID.
+RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
+    chmod a+rwx ${NGINX_CONF_PATH} && \
+    mkdir -p ${NGINX_APP_ROOT}/etc/nginx.d/ && \
+    mkdir -p ${NGINX_APP_ROOT}/etc/nginx.default.d/ && \
+    mkdir -p ${NGINX_APP_ROOT}/src/nginx-start/ && \
+    mkdir -p ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    mkdir -p ${NGINX_LOG_PATH} && \
+    mkdir -p ${NGINX_PERL_MODULE_PATH} && \
+    ln -s ${NGINX_LOG_PATH} /var/log/nginx && \
+    ln -s /etc/opt/rh/rh-nginx${NGINX_SHORT_VER}/nginx /etc/nginx && \
+    ln -s /opt/rh/rh-nginx${NGINX_SHORT_VER}/root/usr/share/nginx /usr/share/nginx && \
+    chmod -R a+rwx ${NGINX_APP_ROOT}/etc && \
+    chmod -R a+rwx /var/opt/rh/rh-nginx${NGINX_SHORT_VER} && \
+    chmod -R a+rwx ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    chown -R 1001:0 ${NGINX_APP_ROOT} && \
+    chown -R 1001:0 /var/opt/rh/rh-nginx${NGINX_SHORT_VER} && \
+    chown -R 1001:0 ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    chmod -R a+rwx /var/run && \
+    chown -R 1001:0 /var/run && \
+    rpm-file-permissions
+
+USER 1001
+
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["/opt/rh/rh-nginx116/root/usr/share/nginx/html"]
+# VOLUME ["/var/opt/rh/rh-nginx116/log/nginx/"]
+
+ENV BASH_ENV=${NGINX_APP_ROOT}/etc/scl_enable \
+    ENV=${NGINX_APP_ROOT}/etc/scl_enable \
+    PROMPT_COMMAND=". ${NGINX_APP_ROOT}/etc/scl_enable"
+
+CMD $STI_SCRIPTS_PATH/usage

--- a/tests/data/nodejs-16/Dockerfile.rhel7
+++ b/tests/data/nodejs-16/Dockerfile.rhel7
@@ -1,0 +1,103 @@
+FROM rhscl/s2i-core-rhel7:1
+
+# RHSCL rh-nginx116 image.
+#
+# Volumes:
+#  * /var/opt/rh/rh-nginx116/log/nginx/ - Storage for logs
+
+EXPOSE 8080
+EXPOSE 8443
+
+ENV NAME=nginx \
+    NGINX_VERSION=1.16 \
+    NGINX_SHORT_VER=116 \
+    PERL_SCL_SHORT_VER=526 \
+    VERSION=0
+
+# Set SCL related variables in Dockerfile so that the collection is enabled by default
+ENV SUMMARY="Platform for running nginx $NGINX_VERSION or building nginx-based application" \
+    DESCRIPTION="Nginx is a web server and a reverse proxy server for HTTP, SMTP, POP3 and IMAP \
+protocols, with a strong focus on high concurrency, performance and low memory usage. The container \
+image provides a containerized packaging of the nginx $NGINX_VERSION daemon. The image can be used \
+as a base image for other applications based on nginx $NGINX_VERSION web server. \
+Nginx server image can be extended using source-to-image tool." \
+    X_SCLS="rh-perl$PERL_SCL_SHORT_VER rh-nginx$NGINX_SHORT_VER" \
+    PATH=/opt/rh/rh-perl$PERL_SCL_SHORT_VER/root/usr/local/bin:/opt/rh/rh-perl$PERL_SCL_SHORT_VER/root/usr/bin:/opt/rh/rh-nginx$NGINX_SHORT_VER/root/usr/bin:/opt/rh/rh-nginx$NGINX_SHORT_VER/root/usr/sbin${PATH:+:${PATH}} \
+    MANPATH=/opt/rh/rh-perl$PERL_SCL_SHORT_VER/root/usr/share/man:/opt/rh/rh-nginx$NGINX_SHORT_VER/root/usr/share/man:${MANPATH} \
+    PKG_CONFIG_PATH=/opt/rh/rh-nginx$NGINX_SHORT_VER/root/usr/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}} \
+    LD_LIBRARY_PATH=/opt/rh/rh-perl$PERL_SCL_SHORT_VER/root/usr/lib64 \
+    PERL5LIB="/opt/rh/rh-nginx$NGINX_SHORT_VER/root/usr/lib64/perl5/vendor_perl${PERL5LIB:+:${PERL5LIB}}"
+
+LABEL summary="${SUMMARY}" \
+      description="${DESCRIPTION}" \
+      io.k8s.description="${DESCRIPTION}" \
+      io.k8s.display-name="Nginx ${NGINX_VERSION}" \
+      io.openshift.expose-services="8080:http" \
+      io.openshift.expose-services="8443:https" \
+      io.openshift.tags="builder,${NAME},rh-${NAME}${NGINX_SHORT_VER}" \
+      com.redhat.component="rh-${NAME}${NGINX_SHORT_VER}-container" \
+      name="rhscl/${NAME}-${NGINX_SHORT_VER}-rhel7" \
+      version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
+      help="For more information visit https://github.com/sclorg/${NAME}-container" \
+      usage="s2i build <SOURCE-REPOSITORY> rhscl/${NAME}-${NGINX_SHORT_VER}-rhel7:latest <APP-NAME>"
+
+ENV NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
+    NGINX_CONF_PATH=/etc/opt/rh/rh-nginx${NGINX_SHORT_VER}/nginx/nginx.conf \
+    NGINX_DEFAULT_CONF_PATH=${APP_ROOT}/etc/nginx.default.d \
+    NGINX_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nginx \
+    NGINX_APP_ROOT=${APP_ROOT} \
+    NGINX_LOG_PATH=/var/opt/rh/rh-nginx${NGINX_SHORT_VER}/log/nginx \
+    NGINX_PERL_MODULE_PATH=${APP_ROOT}/etc/perl
+
+RUN yum install -y yum-utils && \
+    prepare-yum-repositories rhel-server-rhscl-7-rpms && \
+    INSTALL_PKGS="nss_wrapper bind-utils gettext hostname rh-nginx${NGINX_SHORT_VER} rh-nginx${NGINX_SHORT_VER}-nginx \
+                  rh-nginx${NGINX_SHORT_VER}-nginx-mod-stream rh-nginx${NGINX_SHORT_VER}-nginx-mod-http-perl" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum -y clean all --enablerepo='*'
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+# In order to drop the root user, we have to make some directories world
+# writeable as OpenShift default security model is to run the container under
+# random UID.
+RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
+    chmod a+rwx ${NGINX_CONF_PATH} && \
+    mkdir -p ${NGINX_APP_ROOT}/etc/nginx.d/ && \
+    mkdir -p ${NGINX_APP_ROOT}/etc/nginx.default.d/ && \
+    mkdir -p ${NGINX_APP_ROOT}/src/nginx-start/ && \
+    mkdir -p ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    mkdir -p ${NGINX_LOG_PATH} && \
+    mkdir -p ${NGINX_PERL_MODULE_PATH} && \
+    ln -s ${NGINX_LOG_PATH} /var/log/nginx && \
+    ln -s /etc/opt/rh/rh-nginx${NGINX_SHORT_VER}/nginx /etc/nginx && \
+    ln -s /opt/rh/rh-nginx${NGINX_SHORT_VER}/root/usr/share/nginx /usr/share/nginx && \
+    chmod -R a+rwx ${NGINX_APP_ROOT}/etc && \
+    chmod -R a+rwx /var/opt/rh/rh-nginx${NGINX_SHORT_VER} && \
+    chmod -R a+rwx ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    chown -R 1001:0 ${NGINX_APP_ROOT} && \
+    chown -R 1001:0 /var/opt/rh/rh-nginx${NGINX_SHORT_VER} && \
+    chown -R 1001:0 ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    chmod -R a+rwx /var/run && \
+    chown -R 1001:0 /var/run && \
+    rpm-file-permissions
+
+USER 1001
+
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["/opt/rh/rh-nginx116/root/usr/share/nginx/html"]
+# VOLUME ["/var/opt/rh/rh-nginx116/log/nginx/"]
+
+ENV BASH_ENV=${NGINX_APP_ROOT}/etc/scl_enable \
+    ENV=${NGINX_APP_ROOT}/etc/scl_enable \
+    PROMPT_COMMAND=". ${NGINX_APP_ROOT}/etc/scl_enable"
+
+CMD $STI_SCRIPTS_PATH/usage

--- a/tests/data/nodejs-16/README.md
+++ b/tests/data/nodejs-16/README.md
@@ -1,0 +1,207 @@
+Nginx 1.16 server and a reverse proxy server container image
+============================================================
+This container image includes Nginx 1.16 server and a reverse server for OpenShift and general usage.
+Users can choose between RHEL, CentOS and Fedora based images.
+The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
+the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
+and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
+The resulting image can be run using [podman](https://github.com/containers/libpod).
+
+Note: while the examples in this README are calling `podman`, you can replace any such calls by `docker` with the same arguments.
+
+
+Description
+-----------
+
+Nginx is a web server and a reverse proxy server for HTTP, SMTP, POP3 and IMAP
+protocols, with a strong focus on high concurrency, performance and low memory usage. The container
+image provides a containerized packaging of the nginx 1.16 daemon. The image can be used
+as a base image for other applications based on nginx 1.16 web server.
+Nginx server image can be extended using Openshift's `Source` build feature.
+
+
+Usage in OpenShift
+------------------
+In this example, we assume that you are using the `rhel8/nginx-116` image, available through the `nginx:1.16` imagestream tag in Openshift.
+To build a simple [test-app](https://github.com/sclorg/nginx-container/tree/master/examples/1.16/test-app) application in Openshift:
+
+```
+oc new-app nginx:1.16~https://github.com/sclorg/nginx-container.git --context-dir=1.16/test/test-app/
+```
+
+To access the application:
+```
+$ oc get pods
+$ oc exec <pod> -- curl 127.0.0.1:8080
+```
+
+
+Source-to-Image framework and scripts
+-------------------------------------
+This image supports the [Source-to-Image](https://docs.openshift.com/container-platform/4.4/builds/build-strategies.html#images-create-s2i_build-strategies)
+(S2I) strategy in OpenShift. The Source-to-Image is an OpenShift framework
+which makes it easy to write images that take application source code as
+an input, use a builder image like this Nginx container image, and produce
+a new image that runs the assembled application as an output.
+
+In case of Nginx container image, the application source code is typically
+either static HTML pages or configuration files.
+
+To support the Source-to-Image framework, important scripts are included in the builder image:
+
+* The `/usr/libexec/s2i/run` script is set as the default command in the resulting container image (the new image with the application artifacts).
+
+* The `/usr/libexec/s2i/assemble` script inside the image is run to produce a new image with the application artifacts. The script takes sources of a given application (HTML pages), Nginx configuration files, and places them into appropriate directories inside the image. The structure of nginx-app can look like this:
+
+**`./nginx.conf`**--
+       The main nginx configuration file
+
+**`./nginx-cfg/*.conf`**
+       Should contain all nginx configuration we want to include into image
+
+**`./nginx-default-cfg/*.conf`**
+       Contains any nginx config snippets to include in the default server block
+
+**`./nginx-start/*.sh`**
+       Contains shell scripts that are sourced right before nginx is launched
+
+**`./nginx-perl/*.pm`**
+       Contains perl modules to be use by `perl_modules` and `perl_require` directives
+
+**`./`**
+       Should contain nginx application source code
+
+
+Build an application using a Dockerfile
+---------------------------------------
+Compared to the Source-to-Image strategy, using a Dockerfile is a more
+flexible way to build an Nginx container image with an application.
+Use a Dockerfile when Source-to-Image is not sufficiently flexible for you or
+when you build the image outside of the OpenShift environment.
+
+To use the Nginx image in a Dockerfile, follow these steps:
+
+#### 1. Pull a base builder image to build on
+
+podman pull rhel8/nginx-116
+
+#### 2. Pull an application code
+
+An example application available at https://github.com/sclorg/nginx-container.git is used here. To adjust the example application, clone the repository.
+
+```
+git clone https://github.com/sclorg/nginx-container.git nginx-container
+cd nginx-container/examples/1.16/
+```
+
+#### 3. Prepare an application inside a container
+
+This step usually consists of at least these parts:
+
+* putting the application source into the container
+* moving configuration files to the correct place (if available in the application source code)
+* setting the default command in the resulting image
+
+For all these three parts, you can either set up all manually and use the `nginx` command explicitly in the Dockerfile ([3.1.](#31-to-use-own-setup-create-a-dockerfile-with-this-content)), or you can use the Source-to-Image scripts inside the image ([3.2.](#32-to-use-the-source-to-image-scripts-and-build-an-image-using-a-dockerfile-create-a-dockerfile-with-this-content). For more information about these scripts, which enable you to set-up and run the nginx daemon, see the "Source-to-Image framework and scripts" section above.
+
+##### 3.1. To use your own setup, create a Dockerfile with this content:
+
+```
+FROM registry.access.redhat.com/ubi8/nginx-116
+
+# Add application sources
+ADD test-app/nginx.conf "${NGINX_CONF_PATH}"
+ADD test-app/nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"
+ADD test-app/nginx-cfg/*.conf "${NGINX_CONFIGURATION_PATH}"
+ADD test-app/*.html .
+
+# Run script uses standard ways to run the application
+CMD nginx -g "daemon off;"
+```
+
+##### 3.2. To use the Source-to-Image scripts and build an image using a Dockerfile, create a Dockerfile with this content:
+
+```
+FROM registry.access.redhat.com/ubi8/nginx-116
+
+# Add application sources to a directory that the assemble script expects them
+# and set permissions so that the container runs without root access
+# With older docker that does not support --chown option for ADD statement,
+# use these statements instead:
+#  USER 0
+#  ADD app-src /tmp/src
+#  RUN chown -R 1001:0 /tmp/src
+#  USER 1001
+ADD --chown 1001:0 app-src /tmp/src
+
+# Let the assemble script to install the dependencies
+RUN /usr/libexec/s2i/assemble
+
+# Run script uses standard ways to run the application
+CMD /usr/libexec/s2i/run
+```
+
+#### 4. Build a new image from a Dockerfile prepared in the previous step
+```
+podman build -t nginx-app .
+```
+
+#### 5. Run the resulting image with the final application
+```
+podman run -d nginx-app
+```
+
+
+Direct usage with a mounted directory
+-------------------------------------
+An example of the data on the host for the following example:
+```
+$ ls -lZ /wwwdata/html
+-rw-r--r--. 1 1001 1001 54321 Jan 01 12:34 index.html
+-rw-r--r--. 1 1001 1001  5678 Jan 01 12:34 page.html
+```
+
+If you want to run the image directly and mount the static pages available in the `/wwwdata/` directory on the host
+as a container volume, execute the following command:
+
+```
+$ podman run -d --name nginx -p 8080:8080 -v /wwwdata:/opt/app-root/src:Z rhel8/nginx-116 nginx -g "daemon off;"
+```
+
+This creates a container named `nginx` running the Nginx server, serving data from
+the `/wwwdata/` directory. Port 8080 is exposed and mapped to the host.
+You can pull the data from the nginx container using this command:
+
+```
+$ curl -Lk 127.0.0.1:8080
+```
+
+You can replace `/wwwdata/` with location of your web root. Please note that this has to be an **absolute** path, due to podman requirements.
+
+
+Environment variables and volumes
+---------------------------------
+The nginx container image supports the following configuration variable, which can be set by using the `-e` option with the podman run command:
+
+
+**`NGINX_LOG_TO_VOLUME`**
+       When `NGINX_LOG_TO_VOLUME` is set, nginx logs into `/var/log/nginx/`. In case of RHEL-7 and CentOS-7 images, this is a symlink to `/var/opt/rh/rh-nginx116/log/nginx/`.
+
+
+Troubleshooting
+---------------
+By default, nginx access logs are written to standard output and error logs are written to standard error, so both are available in the container log. The log can be examined by running:
+
+    podman logs <container>
+
+**If `NGINX_LOG_TO_VOLUME` variable is set, nginx logs into `/var/log/nginx/`. In case of RHEL-7 and CentOS-7 images, this is a symlink to `/var/opt/rh/rh-nginx116/log/nginx/`, which can be mounted to host system using the container volumes.**
+
+
+See also
+--------
+Dockerfile and other sources for this container image are available on
+https://github.com/sclorg/nginx-container.
+In that repository you also can find another versions of Python environment Dockerfiles.
+Dockerfile for CentOS is called `Dockerfile`, Dockerfile for RHEL7 is called `Dockerfile.rhel7`,
+for RHEL8 it's `Dockerfile.rhel8` and the Fedora Dockerfile is called Dockerfile.fedora.
+

--- a/tests/data/nodejs-16/help.md
+++ b/tests/data/nodejs-16/help.md
@@ -1,0 +1,207 @@
+Nginx 1.16 server and a reverse proxy server container image
+============================================================
+This container image includes Nginx 1.16 server and a reverse server for OpenShift and general usage.
+Users can choose between RHEL, CentOS and Fedora based images.
+The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
+the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
+and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
+The resulting image can be run using [podman](https://github.com/containers/libpod).
+
+Note: while the examples in this README are calling `podman`, you can replace any such calls by `docker` with the same arguments.
+
+
+Description
+-----------
+
+Nginx is a web server and a reverse proxy server for HTTP, SMTP, POP3 and IMAP
+protocols, with a strong focus on high concurrency, performance and low memory usage. The container
+image provides a containerized packaging of the nginx 1.16 daemon. The image can be used
+as a base image for other applications based on nginx 1.16 web server.
+Nginx server image can be extended using Openshift's `Source` build feature.
+
+
+Usage in OpenShift
+------------------
+In this example, we assume that you are using the `rhel8/nginx-116` image, available through the `nginx:1.16` imagestream tag in Openshift.
+To build a simple [test-app](https://github.com/sclorg/nginx-container/tree/master/examples/1.16/test-app) application in Openshift:
+
+```
+oc new-app nginx:1.16~https://github.com/sclorg/nginx-container.git --context-dir=1.16/test/test-app/
+```
+
+To access the application:
+```
+$ oc get pods
+$ oc exec <pod> -- curl 127.0.0.1:8080
+```
+
+
+Source-to-Image framework and scripts
+-------------------------------------
+This image supports the [Source-to-Image](https://docs.openshift.com/container-platform/4.4/builds/build-strategies.html#images-create-s2i_build-strategies)
+(S2I) strategy in OpenShift. The Source-to-Image is an OpenShift framework
+which makes it easy to write images that take application source code as
+an input, use a builder image like this Nginx container image, and produce
+a new image that runs the assembled application as an output.
+
+In case of Nginx container image, the application source code is typically
+either static HTML pages or configuration files.
+
+To support the Source-to-Image framework, important scripts are included in the builder image:
+
+* The `/usr/libexec/s2i/run` script is set as the default command in the resulting container image (the new image with the application artifacts).
+
+* The `/usr/libexec/s2i/assemble` script inside the image is run to produce a new image with the application artifacts. The script takes sources of a given application (HTML pages), Nginx configuration files, and places them into appropriate directories inside the image. The structure of nginx-app can look like this:
+
+**`./nginx.conf`**--
+       The main nginx configuration file
+
+**`./nginx-cfg/*.conf`**
+       Should contain all nginx configuration we want to include into image
+
+**`./nginx-default-cfg/*.conf`**
+       Contains any nginx config snippets to include in the default server block
+
+**`./nginx-start/*.sh`**
+       Contains shell scripts that are sourced right before nginx is launched
+
+**`./nginx-perl/*.pm`**
+       Contains perl modules to be use by `perl_modules` and `perl_require` directives
+
+**`./`**
+       Should contain nginx application source code
+
+
+Build an application using a Dockerfile
+---------------------------------------
+Compared to the Source-to-Image strategy, using a Dockerfile is a more
+flexible way to build an Nginx container image with an application.
+Use a Dockerfile when Source-to-Image is not sufficiently flexible for you or
+when you build the image outside of the OpenShift environment.
+
+To use the Nginx image in a Dockerfile, follow these steps:
+
+#### 1. Pull a base builder image to build on
+
+podman pull rhel8/nginx-116
+
+#### 2. Pull an application code
+
+An example application available at https://github.com/sclorg/nginx-container.git is used here. To adjust the example application, clone the repository.
+
+```
+git clone https://github.com/sclorg/nginx-container.git nginx-container
+cd nginx-container/examples/1.16/
+```
+
+#### 3. Prepare an application inside a container
+
+This step usually consists of at least these parts:
+
+* putting the application source into the container
+* moving configuration files to the correct place (if available in the application source code)
+* setting the default command in the resulting image
+
+For all these three parts, you can either set up all manually and use the `nginx` command explicitly in the Dockerfile ([3.1.](#31-to-use-own-setup-create-a-dockerfile-with-this-content)), or you can use the Source-to-Image scripts inside the image ([3.2.](#32-to-use-the-source-to-image-scripts-and-build-an-image-using-a-dockerfile-create-a-dockerfile-with-this-content). For more information about these scripts, which enable you to set-up and run the nginx daemon, see the "Source-to-Image framework and scripts" section above.
+
+##### 3.1. To use your own setup, create a Dockerfile with this content:
+
+```
+FROM registry.access.redhat.com/ubi8/nginx-116
+
+# Add application sources
+ADD test-app/nginx.conf "${NGINX_CONF_PATH}"
+ADD test-app/nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"
+ADD test-app/nginx-cfg/*.conf "${NGINX_CONFIGURATION_PATH}"
+ADD test-app/*.html .
+
+# Run script uses standard ways to run the application
+CMD nginx -g "daemon off;"
+```
+
+##### 3.2. To use the Source-to-Image scripts and build an image using a Dockerfile, create a Dockerfile with this content:
+
+```
+FROM registry.access.redhat.com/ubi8/nginx-116
+
+# Add application sources to a directory that the assemble script expects them
+# and set permissions so that the container runs without root access
+# With older docker that does not support --chown option for ADD statement,
+# use these statements instead:
+#  USER 0
+#  ADD app-src /tmp/src
+#  RUN chown -R 1001:0 /tmp/src
+#  USER 1001
+ADD --chown 1001:0 app-src /tmp/src
+
+# Let the assemble script to install the dependencies
+RUN /usr/libexec/s2i/assemble
+
+# Run script uses standard ways to run the application
+CMD /usr/libexec/s2i/run
+```
+
+#### 4. Build a new image from a Dockerfile prepared in the previous step
+```
+podman build -t nginx-app .
+```
+
+#### 5. Run the resulting image with the final application
+```
+podman run -d nginx-app
+```
+
+
+Direct usage with a mounted directory
+-------------------------------------
+An example of the data on the host for the following example:
+```
+$ ls -lZ /wwwdata/html
+-rw-r--r--. 1 1001 1001 54321 Jan 01 12:34 index.html
+-rw-r--r--. 1 1001 1001  5678 Jan 01 12:34 page.html
+```
+
+If you want to run the image directly and mount the static pages available in the `/wwwdata/` directory on the host
+as a container volume, execute the following command:
+
+```
+$ podman run -d --name nginx -p 8080:8080 -v /wwwdata:/opt/app-root/src:Z rhel8/nginx-116 nginx -g "daemon off;"
+```
+
+This creates a container named `nginx` running the Nginx server, serving data from
+the `/wwwdata/` directory. Port 8080 is exposed and mapped to the host.
+You can pull the data from the nginx container using this command:
+
+```
+$ curl -Lk 127.0.0.1:8080
+```
+
+You can replace `/wwwdata/` with location of your web root. Please note that this has to be an **absolute** path, due to podman requirements.
+
+
+Environment variables and volumes
+---------------------------------
+The nginx container image supports the following configuration variable, which can be set by using the `-e` option with the podman run command:
+
+
+**`NGINX_LOG_TO_VOLUME`**
+       When `NGINX_LOG_TO_VOLUME` is set, nginx logs into `/var/log/nginx/`. In case of RHEL-7 and CentOS-7 images, this is a symlink to `/var/opt/rh/rh-nginx116/log/nginx/`.
+
+
+Troubleshooting
+---------------
+By default, nginx access logs are written to standard output and error logs are written to standard error, so both are available in the container log. The log can be examined by running:
+
+    podman logs <container>
+
+**If `NGINX_LOG_TO_VOLUME` variable is set, nginx logs into `/var/log/nginx/`. In case of RHEL-7 and CentOS-7 images, this is a symlink to `/var/opt/rh/rh-nginx116/log/nginx/`, which can be mounted to host system using the container volumes.**
+
+
+See also
+--------
+Dockerfile and other sources for this container image are available on
+https://github.com/sclorg/nginx-container.
+In that repository you also can find another versions of Python environment Dockerfiles.
+Dockerfile for CentOS is called `Dockerfile`, Dockerfile for RHEL7 is called `Dockerfile.rhel7`,
+for RHEL8 it's `Dockerfile.rhel8` and the Fedora Dockerfile is called Dockerfile.fedora.
+

--- a/tests/test_distgit.py
+++ b/tests/test_distgit.py
@@ -62,10 +62,10 @@ class TestDistgit(object):
         assert os.path.isfile(dpath)
 
     @pytest.mark.distgit
-    def test_distgit_changes(self):
+    def test_distgit_merge_changes(self):
         self.ir.conf["from_tag"] = "test"
         tmp = Path(self.ir._get_tmp_workdir())
-        self.ir.dist_git_changes()
+        self.ir.dist_git_merge_changes()
         dpath = tmp / self.component / 'Dockerfile'
         assert os.path.isfile(dpath)
         assert not (tmp / self.component / "test" / "test-openshift.yaml").exists()
@@ -77,7 +77,7 @@ class TestDistgit(object):
         shutil.rmtree(tmp / self.component)
 
     @pytest.mark.distgit
-    def test_distgit_changes_openshift_yaml(self):
+    def test_distgit_merge_changes_openshift_yaml(self):
         # TODO
         # As soon as s2i-base-container will contain file 'test/test-openshift.yaml'
         # Then change it to once
@@ -85,7 +85,7 @@ class TestDistgit(object):
         self.ir.conf["from_tag"] = "test"
         tmp = Path(self.ir._get_tmp_workdir())
         self.ir.distgit._clone_downstream(self.component, "main")
-        self.ir.dist_git_changes()
+        self.ir.dist_git_merge_changes()
         dpath = tmp / self.component / 'Dockerfile'
         assert os.path.isfile(dpath)
         tag_found = False
@@ -99,7 +99,7 @@ class TestDistgit(object):
     def test_tag_dockerfile(self):
         tmp = Path(self.ir._get_tmp_workdir())
         self.ir.conf["from_tag"] = "test"
-        self.ir.dist_git_changes()
+        self.ir.dist_git_merge_changes()
         cpath = tmp / self.component
         dpath = cpath / 'Dockerfile'
         found_tag = False


### PR DESCRIPTION
This pull request allows using gitlab for
syncing upstream->downstream.

The rest of the function remains. Like
git clonedownstream uses dist-git.

This pull request covers 'git pullupstream', 'git show', and 'git push'.
The GitLab functionality is valid only for RHEL and RHCWT especially. CWT itself does not make sense for this.
The question is if 'gitlab.py' should be in CWT or should be moved to RHCWT, like 'bugzilla.py' or 'jira.py'

The calling is like this:

```bash
$ cwt -v 5 --config=rhel8.yaml:rhel8.6 --base <base_image> --do-image <image_name> git pullupstream --gitlab
$ cwt -v 5 --config=rhel8.yaml:rhel8.6 --base <base_image> --do-image <image_name> git show --gitlab
$ cwt -v 5 --config=rhel8.yaml:rhel8.6 --base <base_image> --do-image <image_name> git push --gitlab
```

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>