### PR TITLE
Moving common function from DistGitAPI to GitOperations and Dockerfile

### DIFF
--- a/Dockerfile.generator
+++ b/Dockerfile.generator
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:34
+FROM registry.fedoraproject.org/fedora:36
 ENV CWT_DIR=/tmp/container-workflow-tool
 RUN dnf install -y go-md2man \
     make git python3-PyYAML \

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:34
+FROM registry.fedoraproject.org/fedora:36
 
 RUN dnf install -y ansible
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test-in-container build-generator push-generator
+.PHONY: test-in-container build-generator push-generator build
 
 TEST_IMAGE=cwt-tests
 GENERATOR_IMAGE=quay.io/rhscl/cwt-generator

--- a/container_workflow_tool/distgit.py
+++ b/container_workflow_tool/distgit.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import re
 import subprocess
 
 from git import Repo
@@ -8,124 +7,19 @@ from git.exc import GitCommandError
 
 import container_workflow_tool.utility as u
 from container_workflow_tool.utility import RebuilderError
+from container_workflow_tool.dockerfile import DockerfileHandler
+from container_workflow_tool.sync import SyncHandler
+from container_workflow_tool.git_operations import GitOperations
 
 
-class DistgitAPI(object):
+class DistgitAPI(GitOperations):
     """Class for working with dist-git."""
 
-    def __init__(self, base_image, conf, rebuild_reason, logger):
-        self.conf = conf
-        self.base_image = base_image
-        if not rebuild_reason:
-            rebuild_reason = self.conf.rebuild_reason
-        self.rebuild_reason = rebuild_reason.format(base_image=base_image)
-        self.logger = logger if logger else u.setup_logger("dist-git")
+    def __init__(self, *args, **kwargs):
+        super(DistgitAPI, self).__init__(*args, **kwargs)
         self.df_ext = self.conf.df_ext
-
-        self.commit_msg = None
-
-    def set_commit_msg(self, msg):
-        """
-        Set the commit message to some other than the default one.
-
-        Args:
-            msg(str): Message to be written into the commit.
-        """
-        self.commit_msg = msg
-
-    def _get_from_df(self, dockerfile_path):
-        res = None
-        if os.path.exists(dockerfile_path):
-            with open(dockerfile_path) as f:
-                fdata = f.read()
-            res = self._get_from(fdata)
-        return res
-
-    def _get_from(self, fdata: str) -> str:
-        """Gets FROM field from a Dockerfile
-
-        Args:
-            fdata (str): String containing the Dockerfile
-
-        Returns:
-            str: FROM string
-        """
-        registry_base = None
-        image_base = re.search('FROM (.*)\n', fdata)
-        if image_base:
-            registry_base = image_base.group(1)
-        return registry_base
-
-    def _set_from(self, fdata, from_tag):
-        """
-        Updates FROM field from a Dockerfile with value defined in configuration file
-
-        Returns:
-            str: Dockerfile content with updated tag field
-        """
-        self.logger.debug("Setting tag to: " + str(from_tag))
-        base_image = self._get_from(fdata=fdata)
-        self.logger.debug(f"Base image is: {base_image}")
-        imagename_without_tag = base_image.split(':')[0]
-        ret = re.sub("FROM (.*)\n",
-                     f"FROM {imagename_without_tag}:{from_tag}\n", fdata)
-        return ret
-
-    def _update_variable_in_string(self, fdata: str = "", tag: str = "", tag_str: str = "", variable: str = ""):
-        """
-        Updates variable in string. Mainly used for updating test-openshift.yaml file.
-        It replaces VERSION: VERSION_NUMBER -> VERSION: variable and
-        It replaces OS: OS_VERSION -> OS: <os_name>"
-        """
-        self.logger.debug(f"Replaces variable of tag {tag} from {tag_str} to {variable}")
-        ret = re.sub(rf"{tag}: {tag_str}", f"{tag}: \"{variable}\"", fdata)
-        return ret
-
-    def _update_test_openshift_yaml(self, test_openshift_yaml, version: str = "", short_name: str = ""):
-        """
-        Update test/test-openshift.yaml file with value VERSION_NUMBER and OS_NUMBER
-        The file is used for CVP pipeline
-
-        Args:
-            test_openshift_yaml (Path): Path to test/test-openshift.yaml file
-            version (str): version to be replaced with VERSION_NUMBER
-            short_name (str): short_name to be replaced with CONTAINER_NAME
-        """
-        with open(test_openshift_yaml) as f:
-            fdata = f.read()
-        fdata = self._update_variable_in_string(fdata, "VERSION", "VERSION_NUMBER", version)
-        os_name = "fedora"
-        if self.conf.image_names == "RHEL8":
-            os_name = "rhel8"
-        if self.conf.image_names == "RHEL9":
-            os_name = "rhel9"
-        if self.conf.image_names == "RHSCL":
-            os_name = "rhel7"
-        fdata = self._update_variable_in_string(fdata, tag="OS", tag_str="OS_NUMBER", variable=os_name)
-        fdata = self._update_variable_in_string(fdata, tag="SHORT_NAME", tag_str="CONTAINER_NAME", variable=short_name)
-        with open(test_openshift_yaml, 'w') as f:
-            f.write(fdata)
-
-    def _update_dockerfile_rebuild(
-            self, dockerfile_path, from_tag, downstream_from: str = "",
-    ):
-        with open(dockerfile_path) as f:
-            fdata = f.read()
-        res = self._set_from(fdata, from_tag)
-        with open(dockerfile_path, 'w') as f:
-            f.write(res)
-
-    def update_dockerfile(self, df, from_tag, downstream_from: str = ""):
-        """Updates basic fields of a Dockerfile. Sets from field
-
-        Args:
-            df (str): Path to the Dockerfile
-            from_tag (str): value to be inserted into the from field
-            downstream_from (str): value from downstream Dockerfile
-        """
-        self._update_dockerfile_rebuild(
-            df, from_tag, downstream_from=downstream_from
-        )
+        self.df_handler = DockerfileHandler(self.base_image, logger=self.logger)
+        self.sync_handler = SyncHandler(logger=self.logger)
 
     # FIXME: This should be provided by some external Dockerfile linters
     def _check_labels(self, dockerfile_path):
@@ -159,47 +53,6 @@ class DistgitAPI(object):
         else:
             self.logger.info(template.format(name=component, status="OK"))
 
-    def _do_git_reset(self, repo):
-        file_list = ['--', '.gitignore'] + self.conf.ignore_files
-        repo.git.reset(file_list)
-        # One file at a time to make sure all files get reset even on error
-        for f in file_list[1:]:
-            repo.git.checkout('--', f, with_exceptions=False)
-            self.logger.debug("Removing changes for: " + f)
-            # Remove all ignored files that are also untracked
-            untracked = repo.git.ls_files('-o').split('\n')
-            if f in untracked:
-                repo.git.clean('-xfd', f)
-                self.logger.debug("Removing untracked ignored file: " + f)
-
-    def get_commit_msg(self, rebase, image=None, ups_hash=None):
-        """Method to create a commit message to be used in git operations
-
-        Returns a general commit message depending on the value of the rebase
-        argument, or the user-specified commit message.
-
-        Args:
-            rebase (bool): Specify if the rebase message is created
-            image (dict, optional): Metadata about the image being processed
-            ups_hash (str, optional): Upstream commit hash sources were synced from
-
-        Returns:
-            str: Resulting commit message text
-        """
-        if self.commit_msg is not None:
-            return self.commit_msg
-        if rebase is True:
-            commit = "Rebuild for: {}".format(self.rebuild_reason)
-        elif rebase is False:
-            t = "Pull changes from upstream and rebase for: {}"
-            commit = t.format(self.rebuild_reason)
-        else:
-            t = "Unknown rebase argument provided: {}"
-            raise RebuilderError(t.format(str(rebase)))
-        if ups_hash:
-            commit += "\n created from upstream commit: " + ups_hash
-        return commit
-
     def dist_git_changes(self, images, rebase=False):
         """Method to merge changes from upstream into downstream
 
@@ -220,11 +73,11 @@ class DistgitAPI(object):
                 pull_upstr = image.get("pull_upstream", True)
                 repo = self._clone_downstream(component, branch)
                 df_path = os.path.join(component, "Dockerfile")
-                downstream_from = self._get_from_df(df_path)
+                downstream_from = self.df_handler.get_from_df(df_path)
                 self.logger.debug(f"Downstream_from: {downstream_from}\n")
                 from_tag = self.conf.get("from_tag", "latest")
                 if rebase or not pull_upstr:
-                    self.update_dockerfile(
+                    self.df_handler.update_dockerfile(
                         df_path, from_tag, downstream_from=downstream_from
                     )
                     # It is possible for the git repository to have no changes
@@ -243,13 +96,14 @@ class DistgitAPI(object):
                     # Save the upstream commit hash
                     ups_hash = Repo(ups_path).commit().hexsha
                     self._pull_upstream(component, path, url, repo, ups_name, commands)
-                    self.update_dockerfile(
+                    self.df_handler.update_dockerfile(
                         df_path, from_tag, downstream_from=downstream_from
                     )
                     repo.git.add("Dockerfile")
                     # It is possible for the git repository to have no changes
                     if repo.is_dirty():
-                        commit = self.get_commit_msg(rebase, image, ups_hash)
+                        commit = self.get_commit_msg(rebase, image, ups_hash
+                        )
                         if commit:
                             repo.git.commit("-m", commit)
                         else:
@@ -260,187 +114,6 @@ class DistgitAPI(object):
         finally:
             # Cleanup upstream repos
             shutil.rmtree("upstreams", ignore_errors=True)
-
-    def _clone_upstream(self, url, ups_path, commands=None):
-        try:
-            repo = Repo.clone_from(url=url, to_path=ups_path)
-            self.logger.info("Cloned into: " + url)
-            for submodule in repo.submodules:
-                submodule.update(init=True)
-
-        except GitCommandError:
-            # Generally the directory already exists, try to open as a repo instead
-            # Throws InvalidGitRepositoryError if it is not a git repo
-            repo = Repo(ups_path)
-            self.logger.info("Using existing repository.")
-
-        # Run the commands either way
-        self.logger.debug("Running commands in upstream repo.")
-        # Need to be in the upstream git root, so change cwd
-        oldcwd = os.getcwd()
-        os.chdir(ups_path)
-        for order in sorted(commands):
-            cmd = commands[order]
-            self.logger.debug("Running '{o}' command '{c}'".format(o=order,
-                                                                   c=cmd))
-            ret = subprocess.run(cmd, stdout=subprocess.PIPE,
-                                 stderr=subprocess.PIPE, shell=True,
-                                 executable='/bin/bash')
-            if ret.returncode != 0:
-                msg = "'{c}' failed".format(c=cmd.split(" "))
-                self.logger.error(ret.stderr)
-                raise RebuilderError(msg)
-        os.chdir(oldcwd)
-        return repo
-
-    def _copy_upstream2downstream(self, src_parent, dest_parent):
-        """Copies content from upstream repo to downstream repo
-
-        Copies all files/dirs/symlinks from upstream source to dist-git one by one,
-        while removing previous if exists.
-
-        Args:
-            src_parent (string): path to source directory
-            dest_parent (string): path to destination directory
-        """
-        for f in os.listdir(src_parent):
-            dest = os.path.join(dest_parent, f)
-            src = os.path.join(src_parent, f)
-            # First remove the dest
-            if os.path.isdir(dest):
-                self.logger.debug("rmtree {}".format(dest))
-                shutil.rmtree(dest)
-            else:
-                u._remove_file(dest, self.logger)
-
-            # Now copy the src to dest
-            if os.path.islink(src) or not os.path.isdir(src):
-                self.logger.debug("cp {} {}".format(src, dest))
-                shutil.copy2(src, dest, follow_symlinks=False)
-            else:
-                self.logger.debug("cp -r {} {}".format(src, dest))
-                shutil.copytree(src, dest, symlinks=True)
-
-    def _handle_dangling_symlinks(self, src_parent, dest_parent):
-        """Replaces dangling symlinks in destination path with correct content
-
-        We need to remove downstream's (destination) dangling symlinks here,
-        because of files shared for more versions (s2i, root-common, test)
-        in upstream (source).
-        We do it by following first sources's symlink (not all symlinks) and
-        copying rest of the target to the destination.
-
-        Args:
-            src_parent (string): path to source directory
-            dest_parent (string): path to destination directory
-        """
-        for dest_root, dest_dirs, dest_files in os.walk(dest_parent):
-            for dest_file_name in dest_files:
-                dest_file = os.path.join(dest_root, dest_file_name)
-                # Look for danging symlinks to relative path, then copy the content
-                # from source, following the first symlink
-                if os.path.islink(dest_file) and not os.path.isabs(os.readlink(dest_file)):
-                    dest_target = os.path.join(os.path.dirname(dest_file), os.readlink(dest_file))
-                    msg = f"looking for dangling symlink {dest_file} (that points to {dest_target})"
-                    self.logger.debug(msg)
-                    if os.path.exists(dest_target):
-                        continue
-                    # We found a dangling symlink to relative path,
-                    # so we need to use the matching path in source,
-                    # which means removing destination name
-                    # from destination and adding it to source root
-                    dest_path_rel = re.sub(
-                        r"^{comp}{sep}".format(comp=dest_parent, sep=os.path.sep),
-                        "",
-                        dest_file
-                    )
-                    src_path_content = os.path.join(src_parent, dest_path_rel)
-                    self.logger.debug("unlink {dest}".format(dest=dest_file))
-                    os.unlink(dest_file)
-                    src_full = os.path.join(os.path.dirname(src_path_content),
-                                            os.readlink(src_path_content))
-                    if os.path.isdir(src_full):
-                        # In this case, when the source directory includes another symlinks outside
-                        # of this directory, those wouldn't be fixed, so let's run the same function
-                        # to fix dangling symlinks recursively.
-                        self.logger.debug("cp -r {src} {dest}".format(src=src_full, dest=dest_file))
-                        shutil.copytree(src_full, dest_file, symlinks=True)
-                        self._handle_dangling_symlinks(src_parent, dest_parent)
-                    else:
-                        self.logger.debug("cp {src} {dest}".format(src=src_full, dest=dest_file))
-                        shutil.copy2(src_full, dest_file, follow_symlinks=False)
-
-    def _pull_upstream(self, component, path, url, repo, ups_name, commands):
-        """Pulls an upstream repo and copies it into downstream"""
-        ups_path = os.path.join('upstreams/', ups_name)
-        cp_path = os.path.join(ups_path, path)
-
-        # First check if there is a version upstream
-        # If not we just skip the whole copy action
-        if not os.path.exists(cp_path):
-            msg = "Source {} does not exist, skipping copy upstream."
-            self.logger.warning(msg.format(cp_path))
-            return
-
-        for f in repo.git.ls_files().split('\n'):
-            file = os.path.join(component, f)
-            if os.path.isdir(file) and not os.path.islink(file):
-                shutil.rmtree(file)
-            else:
-                os.remove(file)
-
-        # No need for upstream .git files so we remove them
-        shutil.rmtree(os.path.join(ups_path, path, '.git'), ignore_errors=True)
-        self._copy_upstream2downstream(cp_path, component)
-        self._handle_dangling_symlinks(cp_path, component)
-        # If README.md exists but help.md does not, create a symlink
-        help_md = os.path.join(component, "help.md")
-        readme_md = os.path.join(component, "README.md")
-        if not os.path.isfile(help_md):
-            if os.path.isfile(readme_md):
-                os.symlink('README.md', help_md)
-                repo.git.add('help.md')
-            else:
-                # Report warning if help.md does not exists
-                self.logger.warn("help.md file missing")
-        # Add all the changes and remove those we do not want
-        test_openshift_yaml_file = os.path.join(component, "test", "test-openshift.yaml")
-        if os.path.exists(test_openshift_yaml_file):
-            self._update_test_openshift_yaml(test_openshift_yaml_file, path, short_name=ups_name)
-
-        repo.git.add("*")
-        self._do_git_reset(repo)
-        # TODO: Configurable?
-        df_ext = self.df_ext
-        df_path = os.path.join(component, "Dockerfile")
-        if os.path.isfile(df_path + df_ext) and not os.path.islink(df_path + df_ext):
-            try:
-                os.remove(df_path)
-            except FileNotFoundError:
-                # We don't care whether CentOS dockerfile exists or not. Just don't fail here.
-                pass
-            repo.git.mv("Dockerfile" + df_ext, "Dockerfile")
-            os.symlink("Dockerfile", df_path + df_ext)
-            repo.git.add("Dockerfile", "Dockerfile" + df_ext)
-
-        # Make sure a $VERSION symlink exists
-        repo = Repo(component)
-        version = os.path.basename(cp_path)
-        link_name = os.path.join(component, version)
-        if not os.path.islink(link_name):
-            try:
-                os.symlink(".", link_name)
-                repo.git.add(version)
-            except FileExistsError:  # noqa: F821 - Doesnt see built-ins?
-                t = "Failed creating symlink '{}' -> '.', file already exists."
-                raise u.RebuilderError(t.format(link_name))
-
-        # Run post upstream pull hook
-        self._post_upstream_pull(cp_path, component)
-
-    def _post_upstream_pull(sefl, upstream_path, downstream_path):
-        """Post upstream pull hook"""
-        pass
 
     def _clone_downstream(self, component, branch):
         """Clones downstream dist-git repo"""
@@ -475,18 +148,6 @@ class DistgitAPI(object):
             repo = Repo(component)
             repo.git.checkout(branch)
         return repo
-
-    def _get_unpushed_commits(self, repo):
-        """
-        Get unpushed commits
-        :param repo: repo name to check for unpushed commits
-        :return: List of commits or empty array
-        """
-        branch = repo.active_branch.name
-        # Get a list of commits that have not been pushed to remote
-        select = "origin/" + branch + ".." + branch
-        commits = [i for i in repo.iter_commits(select)]
-        return commits
 
     def push_changes(self, tmp, images):
         """Pushes changes for components into downstream dist-git repository"""
@@ -545,46 +206,3 @@ class DistgitAPI(object):
             for image in failed:
                 self.logger.error(u._2sp(image["component"]))
             self.logger.error("Please check the failures and push the changes manually.")
-
-    def show_git_changes(self, tmp, components=None, diff=False):
-        """Shows changes made to tracked files in local downstream repositories
-
-        Walks through all repositories and calls 'git-show' or 'git-diff' on each of them.
-
-        Args:
-            tmp (str): Path to the directory that is used to store git repositories
-            components (list of str, optional): List of components to show changes for
-            diff (boolean, optional): Controls whether the method calls git-show or git-diff
-        """
-        # Function to check if a path contains a git repository
-        def is_git(x): return os.path.isdir(os.path.join(x, '.git'))
-        files = None
-        command = 'diff' if diff else 'show'
-        # Create a list of repository paths
-        if not components:
-            # Get the whole subdirectory
-            files = [f.path for f in os.scandir(tmp) if is_git(f.path)]
-        elif isinstance(components, list):
-            files = [path for path in [os.path.join(tmp, c) for c in components] if is_git(path)]
-        elif isinstance(components, str) and is_git(os.path.join(tmp, components)):
-            files = [os.path.join(tmp, components)]
-        else:
-            raise u.RebuilderError("Unknown component: {}".format(str(components)))
-        if not files:
-            self.logger.warn("No git repositories found in directory " + tmp)
-        # Walk through the repositories and show changes made in the last commit
-        for path in files:
-            repo = Repo(path)
-            # Only show changes if there are unpushed commits to show
-            # or we only want the diff of unstaged changes
-            if self._get_unpushed_commits(repo) or diff:
-                # Clears the screen
-                print(chr(27) + "[2J")
-                # Force pager for short git diffs
-                subprocess.run(
-                    "git config core.pager 'less -+F' --replace-all",
-                    cwd=path,
-                    shell=True
-                )
-                # Not using GitPython as its git.show seems to have some problems with encoding
-                subprocess.run(['git', command], cwd=path)

--- a/container_workflow_tool/dockerfile.py
+++ b/container_workflow_tool/dockerfile.py
@@ -1,0 +1,93 @@
+# MIT License
+#
+# Copyright (c) 2020 SCL team at Red Hat
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import re
+
+import container_workflow_tool.utility as u
+
+
+class DockerfileHandler(object):
+    """Class for handling with Dockerfile files."""
+
+    def __init__(self, base_image, logger):
+        self.base_image = base_image
+        self.logger = logger if logger else u.setup_logger("dockerfile")
+
+    def get_from_df(self, dockerfile_path):
+        res = None
+        if os.path.exists(dockerfile_path):
+            with open(dockerfile_path) as f:
+                fdata = f.read()
+            res = self.get_from(fdata)
+        return res
+
+    def get_from(self, fdata: str) -> str:
+        """Gets FROM field from a Dockerfile
+
+        Args:
+            fdata (str): String containing the Dockerfile
+
+        Returns:
+            str: FROM string
+        """
+        registry_base = None
+        image_base = re.search('FROM (.*)\n', fdata)
+        if image_base:
+            registry_base = image_base.group(1)
+        return registry_base
+
+    def set_from(self, fdata, from_tag):
+        """
+        Updates FROM field from a Dockerfile with value defined in configuration file
+
+        Returns:
+            str: Dockerfile content with updated tag field
+        """
+        self.logger.debug("Setting tag to: " + str(from_tag))
+        base_image = self.get_from(fdata=fdata)
+        self.logger.debug(f"Base image is: {base_image}")
+        imagename_without_tag = base_image.split(':')[0]
+        ret = re.sub("FROM (.*)\n",
+                     f"FROM {imagename_without_tag}:{from_tag}\n", fdata)
+        return ret
+
+    def update_dockerfile_rebuild(
+            self, dockerfile_path, from_tag, downstream_from: str = "",
+    ):
+        with open(dockerfile_path) as f:
+            fdata = f.read()
+        res = self.set_from(fdata, from_tag)
+        with open(dockerfile_path, 'w') as f:
+            f.write(res)
+
+    def update_dockerfile(self, df, from_tag, downstream_from: str = ""):
+        """Updates basic fields of a Dockerfile. Sets from field
+
+        Args:
+            df (str): Path to the Dockerfile
+            from_tag (str): value to be inserted into the from field
+            downstream_from (str): value from downstream Dockerfile
+        """
+        self.update_dockerfile_rebuild(
+            df, from_tag, downstream_from=downstream_from
+        )

--- a/container_workflow_tool/git_operations.py
+++ b/container_workflow_tool/git_operations.py
@@ -1,0 +1,291 @@
+# MIT License
+#
+# Copyright (c) 2020 SCL team at Red Hat
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import subprocess
+import shutil
+import re
+
+from git import Repo
+from git.exc import GitCommandError
+
+import container_workflow_tool.utility as u
+from container_workflow_tool.utility import RebuilderError
+
+
+class GitOperations(object):
+    """Class for working with git."""
+
+    def __init__(self, base_image, conf, rebuild_reason, logger):
+        self.conf = conf
+        self.base_image = base_image
+        if not rebuild_reason:
+            rebuild_reason = self.conf.rebuild_reason
+        self.rebuild_reason = rebuild_reason.format(base_image=base_image)
+        self.logger = logger if logger else u.setup_logger("git-ops")
+        self.df_ext = self.conf.df_ext
+
+        self.commit_msg = None
+
+    def set_commit_msg(self, msg):
+        """
+        Set the commit message to some other than the default one.
+
+        Args:
+            msg(str): Message to be written into the commit.
+        """
+        self.commit_msg = msg
+
+    def _do_git_reset(self, repo):
+        file_list = ['--', '.gitignore'] + self.conf.ignore_files
+        repo.git.reset(file_list)
+        # One file at a time to make sure all files get reset even on error
+        for f in file_list[1:]:
+            repo.git.checkout('--', f, with_exceptions=False)
+            self.logger.debug("Removing changes for: " + f)
+            # Remove all ignored files that are also untracked
+            untracked = repo.git.ls_files('-o').split('\n')
+            if f in untracked:
+                repo.git.clean('-xfd', f)
+                self.logger.debug("Removing untracked ignored file: " + f)
+
+    def _clone_upstream(self, url, ups_path, commands=None):
+        try:
+            repo = Repo.clone_from(url=url, to_path=ups_path)
+            self.logger.info("Cloned into: " + url)
+            for submodule in repo.submodules:
+                submodule.update(init=True)
+
+        except GitCommandError:
+            # Generally the directory already exists, try to open as a repo instead
+            # Throws InvalidGitRepositoryError if it is not a git repo
+            repo = Repo(ups_path)
+            self.logger.info("Using existing repository.")
+
+        # Run the commands either way
+        self.logger.debug("Running commands in upstream repo.")
+        # Need to be in the upstream git root, so change cwd
+        oldcwd = os.getcwd()
+        os.chdir(ups_path)
+        for order in sorted(commands):
+            cmd = commands[order]
+            self.logger.debug("Running '{o}' command '{c}'".format(o=order,
+                                                                   c=cmd))
+            ret = subprocess.run(cmd, stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE, shell=True,
+                                 executable='/bin/bash')
+            if ret.returncode != 0:
+                msg = "'{c}' failed".format(c=cmd.split(" "))
+                self.logger.error(ret.stderr)
+                raise RebuilderError(msg)
+        os.chdir(oldcwd)
+        return repo
+
+    def _get_unpushed_commits(self, repo):
+        """
+        Get unpushed commits
+        :param repo: repo name to check for unpushed commits
+        :return: List of commits or empty array
+        """
+        branch = repo.active_branch.name
+        # Get a list of commits that have not been pushed to remote
+        select = "origin/" + branch + ".." + branch
+        commits = [i for i in repo.iter_commits(select)]
+        return commits
+
+    def show_git_changes(self, tmp, components=None, diff=False):
+        """Shows changes made to tracked files in local downstream repositories
+
+        Walks through all repositories and calls 'git-show' or 'git-diff' on each of them.
+
+        Args:
+            tmp (str): Path to the directory that is used to store git repositories
+            components (list of str, optional): List of components to show changes for
+            diff (boolean, optional): Controls whether the method calls git-show or git-diff
+        """
+        # Function to check if a path contains a git repository
+        def is_git(x): return os.path.isdir(os.path.join(x, '.git'))
+        files = None
+        command = 'diff' if diff else 'show'
+        # Create a list of repository paths
+        if not components:
+            # Get the whole subdirectory
+            files = [f.path for f in os.scandir(tmp) if is_git(f.path)]
+        elif isinstance(components, list):
+            files = [path for path in [os.path.join(tmp, c) for c in components] if is_git(path)]
+        elif isinstance(components, str) and is_git(os.path.join(tmp, components)):
+            files = [os.path.join(tmp, components)]
+        else:
+            raise u.RebuilderError("Unknown component: {}".format(str(components)))
+        if not files:
+            self.logger.warn("No git repositories found in directory " + tmp)
+        # Walk through the repositories and show changes made in the last commit
+        for path in files:
+            repo = Repo(path)
+            # Only show changes if there are unpushed commits to show
+            # or we only want the diff of unstaged changes
+            if self._get_unpushed_commits(repo) or diff:
+                # Clears the screen
+                print(chr(27) + "[2J")
+                # Force pager for short git diffs
+                subprocess.run(
+                    "git config core.pager 'less -+F' --replace-all",
+                    cwd=path,
+                    shell=True
+                )
+                # Not using GitPython as its git.show seems to have some problems with encoding
+                subprocess.run(['git', command], cwd=path)
+
+    def update_variable_in_string(self, fdata: str = "", tag: str = "", tag_str: str = "", variable: str = ""):
+        """
+        Updates variable in string. Mainly used for updating test-openshift.yaml file.
+        It replaces VERSION: VERSION_NUMBER -> VERSION: variable and
+        It replaces OS: OS_VERSION -> OS: <os_name>"
+        """
+        ret = re.sub(rf"{tag}: {tag_str}", f"{tag}: \"{variable}\"", fdata)
+        return ret
+
+    def update_test_openshift_yaml(self, test_openshift_yaml, version: str = "", short_name: str = ""):
+        """
+        Update test/test-openshift.yaml file with value VERSION_NUMBER and OS_NUMBER
+        The file is used for CVP pipeline
+        Args:
+            test_openshift_yaml (Path): Path to test/test-openshift.yaml file
+            version (str): version to be replaced with VERSION_NUMBER
+            short_name (str): short_name to be replaced with CONTAINER_NAME
+            image_names (str): image_names specified to be replaced with OS_NUMBER
+        """
+        with open(test_openshift_yaml) as f:
+            fdata = f.read()
+        fdata = self.update_variable_in_string(fdata, "VERSION", "VERSION_NUMBER", version)
+        os_name = "fedora"
+        if self.conf.image_names == "RHEL8":
+            os_name = "rhel8"
+        if self.conf.image_names == "RHEL9":
+            os_name = "rhel9"
+        if self.conf.image_names == "RHSCL":
+            os_name = "rhel7"
+        fdata = self.update_variable_in_string(fdata, tag="OS", tag_str="OS_NUMBER", variable=os_name)
+        fdata = self.update_variable_in_string(fdata, tag="SHORT_NAME", tag_str="CONTAINER_NAME", variable=short_name)
+        with open(test_openshift_yaml, 'w') as f:
+            f.write(fdata)
+
+    def get_commit_msg(self, rebase, image=None, ups_hash=None):
+        """Method to create a commit message to be used in git operations
+
+        Returns a general commit message depending on the value of the rebase
+        argument, or the user-specified commit message.
+
+        Args:
+            rebase (bool): Specify if the rebase message is created
+            image (dict, optional): Metadata about the image being processed
+            ups_hash (str, optional): Upstream commit hash sources were synced from
+
+        Returns:
+            str: Resulting commit message text
+        """
+        if self.commit_msg is not None:
+            return self.commit_msg
+        if rebase is True:
+            commit = "Rebuild for: {}".format(self.rebuild_reason)
+        elif rebase is False:
+            t = "Pull changes from upstream and rebase for: {}"
+            commit = t.format(self.rebuild_reason)
+        else:
+            t = "Unknown rebase argument provided: {}"
+            raise RebuilderError(t.format(str(rebase)))
+        if ups_hash:
+            commit += "\n created from upstream commit: " + ups_hash
+        return commit
+
+
+    def _pull_upstream(self, component, path, url, repo, ups_name, commands):
+        """Pulls an upstream repo and copies it into downstream"""
+        ups_path = os.path.join('upstreams/', ups_name)
+        cp_path = os.path.join(ups_path, path)
+
+        # First check if there is a version upstream
+        # If not we just skip the whole copy action
+        if not os.path.exists(cp_path):
+            msg = "Source {} does not exist, skipping copy upstream."
+            self.logger.warning(msg.format(cp_path))
+            return
+
+        for f in repo.git.ls_files().split('\n'):
+            file = os.path.join(component, f)
+            if os.path.isdir(file) and not os.path.islink(file):
+                shutil.rmtree(file)
+            else:
+                os.remove(file)
+
+        # No need for upstream .git files so we remove them
+        shutil.rmtree(os.path.join(ups_path, path, '.git'), ignore_errors=True)
+        self.sync_handler.copy_upstream2downstream(cp_path, component)
+        self.sync_handler.handle_dangling_symlinks(cp_path, component)
+        # If README.md exists but help.md does not, create a symlink
+        help_md = os.path.join(component, "help.md")
+        readme_md = os.path.join(component, "README.md")
+        if not os.path.isfile(help_md):
+            if os.path.isfile(readme_md):
+                os.symlink('README.md', help_md)
+                repo.git.add('help.md')
+            else:
+                # Report warning if help.md does not exists
+                self.logger.warn("help.md file missing")
+        # Add all the changes and remove those we do not want
+        test_openshift_yaml_file = os.path.join(component, "test", "test-openshift.yaml")
+        if os.path.exists(test_openshift_yaml_file):
+            self.update_test_openshift_yaml(test_openshift_yaml_file, path, short_name=ups_name)
+
+        repo.git.add("*")
+        self._do_git_reset(repo)
+        # TODO: Configurable?
+        df_ext = self.df_ext
+        df_path = os.path.join(component, "Dockerfile")
+        if os.path.isfile(df_path + df_ext) and not os.path.islink(df_path + df_ext):
+            try:
+                os.remove(df_path)
+            except FileNotFoundError:
+                # We don't care whether CentOS dockerfile exists or not. Just don't fail here.
+                pass
+            repo.git.mv("Dockerfile" + df_ext, "Dockerfile")
+            os.symlink("Dockerfile", df_path + df_ext)
+            repo.git.add("Dockerfile", "Dockerfile" + df_ext)
+
+        # Make sure a $VERSION symlink exists
+        repo = Repo(component)
+        version = os.path.basename(cp_path)
+        link_name = os.path.join(component, version)
+        if not os.path.islink(link_name):
+            try:
+                os.symlink(".", link_name)
+                repo.git.add(version)
+            except FileExistsError:  # noqa: F821 - Doesnt see built-ins?
+                t = "Failed creating symlink '{}' -> '.', file already exists."
+                raise u.RebuilderError(t.format(link_name))
+
+        # Run post upstream pull hook
+        self._post_upstream_pull(cp_path, component)
+
+    def _post_upstream_pull(self, upstream_path, downstream_path):
+        """Post upstream pull hook"""
+        pass

--- a/container_workflow_tool/main.py
+++ b/container_workflow_tool/main.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import container_workflow_tool.utility as u
 from container_workflow_tool.koji import KojiAPI
 from container_workflow_tool.distgit import DistgitAPI
+from container_workflow_tool.git_operations import GitOperations
 from container_workflow_tool.utility import RebuilderError
 from container_workflow_tool.config import Config
 
@@ -43,6 +44,7 @@ class ImageRebuilder:
 
         self._brewapi: KojiAPI = None
         self._distgit: DistgitAPI = None
+        self._git_ops: GitOperations = None
         self.commit_msg = None
         self.args = None
         self.tmp_workdir: str = None
@@ -139,15 +141,23 @@ class ImageRebuilder:
     def distgit(self):
         if not self._distgit:
             self._distgit = DistgitAPI(self.base_image, self.conf,
-                                      self.rebuild_reason,
-                                      self.logger.getChild("dist-git"))
+                                       self.rebuild_reason,
+                                       self.logger.getChild("dist-git"))
         return self._distgit
+
+    @property
+    def git_ops(self):
+        if not self._git_ops:
+            self._git_ops = GitOperations(self.base_image, self.conf,
+                                          self.rebuild_reason,
+                                          self.logger.getChild("-git-ops"))
+        return self._git_ops
 
     @property
     def brewapi(self):
         if not self._brewapi:
             self._brewapi = KojiAPI(self.conf, self.logger.getChild("koji"),
-                                   self.latest_release)
+                                    self.latest_release)
         return self._brewapi
 
     def _setup_logger(self, level=logging.INFO, user_logger=None, name=__name__):

--- a/container_workflow_tool/sync.py
+++ b/container_workflow_tool/sync.py
@@ -1,0 +1,110 @@
+# MIT License
+#
+# Copyright (c) 2020 SCL team at Red Hat
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import shutil
+import re
+import container_workflow_tool.utility as u
+
+
+class SyncHandler(object):
+    """Class for handling with Dockerfile files."""
+
+    def __init__(self, logger):
+        self.logger = logger if logger else u.setup_logger("sync_handler")
+
+    def copy_upstream2downstream(self, src_parent, dest_parent):
+        """Copies content from upstream repo to downstream repo
+
+        Copies all files/dirs/symlinks from upstream source to dist-git one by one,
+        while removing previous if exists.
+
+        Args:
+            src_parent (string): path to source directory
+            dest_parent (string): path to destination directory
+        """
+        for f in os.listdir(src_parent):
+            dest = os.path.join(dest_parent, f)
+            src = os.path.join(src_parent, f)
+            # First remove the dest
+            if os.path.isdir(dest):
+                self.logger.debug("rmtree {}".format(dest))
+                shutil.rmtree(dest)
+            else:
+                u._remove_file(dest, self.logger)
+
+            # Now copy the src to dest
+            if os.path.islink(src) or not os.path.isdir(src):
+                self.logger.debug("cp {} {}".format(src, dest))
+                shutil.copy2(src, dest, follow_symlinks=False)
+            else:
+                self.logger.debug("cp -r {} {}".format(src, dest))
+                shutil.copytree(src, dest, symlinks=True)
+
+    def handle_dangling_symlinks(self, src_parent, dest_parent):
+        """Replaces dangling symlinks in destination path with correct content
+
+        We need to remove downstream's (destination) dangling symlinks here,
+        because of files shared for more versions (s2i, root-common, test)
+        in upstream (source).
+        We do it by following first sources's symlink (not all symlinks) and
+        copying rest of the target to the destination.
+
+        Args:
+            src_parent (string): path to source directory
+            dest_parent (string): path to destination directory
+        """
+        for dest_root, dest_dirs, dest_files in os.walk(dest_parent):
+            for dest_file_name in dest_files:
+                dest_file = os.path.join(dest_root, dest_file_name)
+                # Look for danging symlinks to relative path, then copy the content
+                # from source, following the first symlink
+                if os.path.islink(dest_file) and not os.path.isabs(os.readlink(dest_file)):
+                    dest_target = os.path.join(os.path.dirname(dest_file), os.readlink(dest_file))
+                    msg = f"looking for dangling symlink {dest_file} (that points to {dest_target})"
+                    self.logger.debug(msg)
+                    if os.path.exists(dest_target):
+                        continue
+                    # We found a dangling symlink to relative path,
+                    # so we need to use the matching path in source,
+                    # which means removing destination name
+                    # from destination and adding it to source root
+                    dest_path_rel = re.sub(
+                        r"^{comp}{sep}".format(comp=dest_parent, sep=os.path.sep),
+                        "",
+                        dest_file
+                    )
+                    src_path_content = os.path.join(src_parent, dest_path_rel)
+                    self.logger.debug("unlink {dest}".format(dest=dest_file))
+                    os.unlink(dest_file)
+                    src_full = os.path.join(os.path.dirname(src_path_content),
+                                            os.readlink(src_path_content))
+                    if os.path.isdir(src_full):
+                        # In this case, when the source directory includes another symlinks outside
+                        # of this directory, those wouldn't be fixed, so let's run the same function
+                        # to fix dangling symlinks recursively.
+                        self.logger.debug("cp -r {src} {dest}".format(src=src_full, dest=dest_file))
+                        shutil.copytree(src_full, dest_file, symlinks=True)
+                        self.handle_dangling_symlinks(src_parent, dest_parent)
+                    else:
+                        self.logger.debug("cp {src} {dest}".format(src=src_full, dest=dest_file))
+                        shutil.copy2(src_full, dest_file, follow_symlinks=False)

--- a/container_workflow_tool/utility.py
+++ b/container_workflow_tool/utility.py
@@ -1,6 +1,7 @@
 import sys
 import argparse
 import os
+import re
 import logging
 
 import textwrap

--- a/tests/test_distgit.py
+++ b/tests/test_distgit.py
@@ -29,7 +29,7 @@ from pathlib import Path
 
 from tests.spellbook import DATA_DIR
 from container_workflow_tool.cli import ImageRebuilder
-from container_workflow_tool.distgit import DistgitAPI
+from container_workflow_tool.git_operations import GitOperations
 
 
 class TestDistgit(object):
@@ -82,7 +82,7 @@ class TestDistgit(object):
         # TODO
         # As soon as s2i-base-container will contain file 'test/test-openshift.yaml'
         # Then change it to once
-        flexmock(DistgitAPI).should_receive("_update_test_openshift_yaml").never()
+        flexmock(GitOperations).should_receive("update_test_openshift_yaml").never()
         self.ir.conf["from_tag"] = "test"
         tmp = Path(self.ir._get_tmp_workdir())
         self.ir.distgit._clone_downstream(self.component, "main")
@@ -97,12 +97,6 @@ class TestDistgit(object):
         shutil.rmtree(tmp / self.component)
 
     @pytest.mark.distgit
-    def test_distgit_commit_msg(self):
-        msg = "Unit testing"
-        self.ir.set_commit_msg(msg)
-        assert self.ir.distgit.commit_msg == msg
-
-    @pytest.mark.distgit
     def test_tag_dockerfile(self):
         tmp = Path(self.ir._get_tmp_workdir())
         self.ir.conf["from_tag"] = "test"
@@ -115,50 +109,3 @@ class TestDistgit(object):
                 found_tag = True
         assert found_tag
         shutil.rmtree(tmp / self.component)
-
-    @pytest.mark.parametrize(
-        "tag,tag_str,variable,expected",
-        [
-            ("VERSION", "VERSION_NUMBER", "base", True),
-            ("VERSION", "VERSION_NUMBER", "1.14", True),
-            ("VERSION", "\"VERSION_NUMBER\"", "1.14", False),
-            ("OS", "OS_NUMBER", "rhel8", True),
-            ("VER", "VERSION_NUMBER", "base", False),
-            ("OS", "OS_NUMBER", "rhel9", True),
-            ("OS", "\"OS_NUMBER\"", "rhel9", False),
-            ("OS", "VERSION_NUMBER", "base", False),
-            ("VERSION", "VERSIONS_NUMBER", "1.14", False),
-            ("SHORT_NAME", "CONTAINER_NAME", "nodejs", True),
-            ("SHORT_NAME", "\"CONTAINER_NAME\"", "nodejs", False),
-            ("SHORT_NAME", "CONT_NAME", "nodejs", False),
-            ("SHORTNAME", "CONTAINER_NAME", "nodejs", False),
-        ]
-    )
-    def test_update_variable_in_string(self, tag, tag_str, variable, expected):
-        with open(os.path.join(DATA_DIR, "test-openshift.yaml")) as f:
-            yaml_file = f.read()
-        fixed = self.ir.distgit._update_variable_in_string(fdata=yaml_file, tag=tag, tag_str=tag_str, variable=variable)
-        result = f"{tag}: \"{variable}\"" in fixed
-        assert result == expected
-
-    @pytest.mark.parametrize(
-        "os_name,os_name_expected,version",
-        [
-            ("fedora", "fedora", "base"),
-            ("RHEL8", "rhel8", "1.14"),
-            ("RHEL9", "rhel9", "1.14"),
-            ("RHSCL", "rhel7", "14"),
-            ("FOO", "fedora", "bar")
-        ]
-    )
-    def test_update_openshift_yaml(self, os_name, os_name_expected, version):
-        self.ir.conf.image_names = os_name
-        tmp = Path(self.ir._get_tmp_workdir())
-        file_name = "test-openshift.yaml"
-        target_name = tmp / file_name
-        shutil.copy(os.path.join(DATA_DIR, file_name), target_name)
-        self.ir.distgit._update_test_openshift_yaml(str(target_name), version=version)
-        with open(target_name) as f:
-            content = f.read()
-        assert f"VERSION: \"{version}\"" in content
-        assert f"OS: \"{os_name_expected}\"" in content

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -1,0 +1,99 @@
+# MIT License
+#
+# Copyright (c) 2020 SCL team at Red Hat
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import pytest
+import shutil
+
+from pathlib import Path
+from flexmock import flexmock
+
+from container_workflow_tool.cli import ImageRebuilder
+
+from tests.spellbook import DATA_DIR
+
+
+class TestGitOperations(object):
+
+    def setup_method(self):
+        self.component = 's2i-base'
+        self.ir = ImageRebuilder('Testing')
+
+        self.ir.set_config('default.yaml', release="rawhide")
+        # Partner BZ testing
+        self.ir.rebuild_reason = "Unit testing"
+        self.ir.disable_klist = True
+        self.ir.set_do_images([self.component])
+
+
+    @pytest.mark.distgit
+    def test_distgit_commit_msg(self):
+        msg = "Unit testing"
+        self.ir.set_commit_msg(msg)
+        assert self.ir.distgit.commit_msg == msg
+
+    @pytest.mark.parametrize(
+        "os_name,os_name_expected,version",
+        [
+            ("fedora", "fedora", "base"),
+            ("RHEL8", "rhel8", "1.14"),
+            ("RHEL9", "rhel9", "1.14"),
+            ("RHSCL", "rhel7", "14"),
+            ("FOO", "fedora", "bar")
+        ]
+    )
+    def test_update_openshift_yaml(self, os_name, os_name_expected, version):
+        self.ir.conf.image_names = os_name
+        tmp = Path(self.ir._get_tmp_workdir())
+        file_name = "test-openshift.yaml"
+        target_name = tmp / file_name
+        shutil.copy(os.path.join(DATA_DIR, file_name), target_name)
+        self.ir.git_ops.update_test_openshift_yaml(str(target_name), version=version)
+        with open(target_name) as f:
+            content = f.read()
+        assert f"VERSION: \"{version}\"" in content
+        assert f"OS: \"{os_name_expected}\"" in content
+
+    @pytest.mark.parametrize(
+        "tag,tag_str,variable,expected",
+        [
+            ("VERSION", "VERSION_NUMBER", "base", True),
+            ("VERSION", "VERSION_NUMBER", "1.14", True),
+            ("VERSION", "\"VERSION_NUMBER\"", "1.14", False),
+            ("OS", "OS_NUMBER", "rhel8", True),
+            ("VER", "VERSION_NUMBER", "base", False),
+            ("OS", "OS_NUMBER", "rhel9", True),
+            ("OS", "\"OS_NUMBER\"", "rhel9", False),
+            ("OS", "VERSION_NUMBER", "base", False),
+            ("VERSION", "VERSIONS_NUMBER", "1.14", False),
+            ("SHORT_NAME", "CONTAINER_NAME", "nodejs", True),
+            ("SHORT_NAME", "\"CONTAINER_NAME\"", "nodejs", False),
+            ("SHORT_NAME", "CONT_NAME", "nodejs", False),
+            ("SHORTNAME", "CONTAINER_NAME", "nodejs", False),
+        ]
+    )
+    def test_update_variable_in_string(self, tag, tag_str, variable, expected):
+        with open(os.path.join(DATA_DIR, "test-openshift.yaml")) as f:
+            yaml_file = f.read()
+        fixed = self.ir.git_ops.update_variable_in_string(fdata=yaml_file, tag=tag, tag_str=tag_str, variable=variable)
+        result = f"{tag}: \"{variable}\"" in fixed
+        assert result == expected


### PR DESCRIPTION
What is done in this function:

- Dockerfile.generator is moved from F34 -> F36
- Dockerfile.tests is moved from F34->F36
- Functions `get_from_df`, `get_from`, `set_from`, `update_dockerfile`, and `update_dockerfile_rebuild` are moved from distgit.py to dockerfile.py
- Functions `set_commit_msg`, `_do_git_reset`, `_clone_upstream`, `_get_unpushed_commits`, `show_git_changes`, `update_variable_in_string`, `update_test_openshift_yaml`, `get_commit_msg`, `_pull_upstream` are moved from distgit.py to git_operations.py
- Functions `copy_upstream2downstream`, `handle_dangling_symlinks` are moved from distgit.py to sync.py file.

All there changes are check by Test Suite.