### PR TITLE
Fix traceback in case source file does not exist.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def get_dir(system_path=None, virtual_path=None):
 
 setup(
     name='container-workflow-tool',
-    version="1.5.5",
+    version="1.5.6",
     description='A python3 tool to make rebuilding images easier by automating several steps of the process.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Fix traceback in case source file does not exist.
Also use f"" syntax instead of .format


Error from upstream->downstream was:

```bash
rh_cwt.main.distgit - DEBUG: looking for dangling symlink httpd-24/test/run (that points to httpd-24/test/../../test/run)
rh_cwt.main.distgit - DEBUG: unlink httpd-24/test/run
rh_cwt.main.distgit - DEBUG: cp upstreams/httpd/2.4/test/../../test/run httpd-24/test/run
rh_cwt.main.distgit - DEBUG: looking for dangling symlink httpd-24/test/run-openshift (that points to httpd-24/test/../../test/run-openshift)
rh_cwt.main.distgit - DEBUG: unlink httpd-24/test/run-openshift
rh_cwt.main.distgit - DEBUG: cp upstreams/httpd/2.4/test/../../test/run-openshift httpd-24/test/run-openshift
Traceback (most recent call last):
  File "/usr/local/bin/rhcwt", line 33, in <module>
    sys.exit(load_entry_point('rhcwt==0.9.8', 'console_scripts', 'rhcwt')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/rh_cwt/cli.py", line 221, in run
    cli.run()
  File "/usr/local/lib/python3.11/site-packages/rh_cwt/cli.py", line 215, in run
    run_function()
  File "/usr/local/lib/python3.11/site-packages/rh_cwt/main.py", line 557, in dist_git_merge_changes
    super(RhelImageRebuilder, self).dist_git_merge_changes(rebase)
  File "/usr/local/lib/python3.11/site-packages/container_workflow_tool/main.py", line 577, in dist_git_merge_changes
    self.distgit.dist_git_merge_changes(images, rebase)
  File "/usr/local/lib/python3.11/site-packages/container_workflow_tool/distgit.py", line 99, in dist_git_merge_changes
    self.pull_upstream(component, path, url, repo, ups_name, commands)
  File "/usr/local/lib/python3.11/site-packages/container_workflow_tool/git_operations.py", line 259, in pull_upstream
    self.sync_handler.handle_dangling_symlinks(cp_path, component)
  File "/usr/local/lib/python3.11/site-packages/container_workflow_tool/sync.py", line 108, in handle_dangling_symlinks
    self.handle_dangling_symlinks(src_parent, dest_parent)
  File "/usr/local/lib/python3.11/site-packages/container_workflow_tool/sync.py", line 108, in handle_dangling_symlinks
    self.handle_dangling_symlinks(src_parent, dest_parent)
  File "/usr/local/lib/python3.11/site-packages/container_workflow_tool/sync.py", line 111, in handle_dangling_symlinks
    shutil.copy2(src_full, dest_file, follow_symlinks=False)
  File "/usr/lib64/python3.11/shutil.py", line 436, in copy2
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib64/python3.11/shutil.py", line 256, in copyfile
    with open(src, 'rb') as fsrc:
         ^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'upstreams/httpd/2.4/test/../../test/run-openshift'
```
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
