### PR TITLE
Update dockerfile is needed also for GitLab project forks

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           dockerfiles: ./Dockerfile.generator
           image: cwt-generator
-          tags: latest 1 ${{ github.sha }} 1.5.8
+          tags: latest 1 ${{ github.sha }} 1.5.9
 
       - name: Push cwt-generator image to Quay.io
         id: push-to-quay

--- a/container_workflow_tool/distgit.py
+++ b/container_workflow_tool/distgit.py
@@ -77,10 +77,10 @@ class DistgitAPI(GitOperations):
                 downstream_from = self.df_handler.get_from_df(df_path)
                 self.logger.debug(f"Downstream_from: {downstream_from}\n")
                 from_tag = self.conf.get("from_tag", "latest")
-                self.df_handler.update_dockerfile(
-                     df_path, from_tag, downstream_from=downstream_from
-                )
                 if rebase or not pull_upstr:
+                    self.df_handler.update_dockerfile(
+                        df_path, from_tag, downstream_from=downstream_from
+                    )
                     # It is possible for the git repository to have no changes
                     if repo.is_dirty():
                         commit = self.get_commit_msg(rebase, image)
@@ -97,6 +97,9 @@ class DistgitAPI(GitOperations):
                     # Save the upstream commit hash
                     ups_hash = Repo(ups_path).commit().hexsha
                     self.pull_upstream(component, path, url, repo, ups_name, commands)
+                    self.df_handler.update_dockerfile(
+                        df_path, from_tag, downstream_from=downstream_from
+                    )
                     repo.git.add("Dockerfile")
                     # It is possible for the git repository to have no changes
                     if repo.is_dirty():

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def get_dir(system_path=None, virtual_path=None):
 
 setup(
     name='container-workflow-tool',
-    version="1.5.8",
+    version="1.5.9",
     description='A python3 tool to make rebuilding images easier by automating several steps of the process.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
In case GitLab forks are used we need to update forks as well.

Therefore update_dockerfile is needed.
