### PR TITLE
Fix for 'src_path_content' in upstream does not exist

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           dockerfiles: ./Dockerfile.generator
           image: cwt-generator
-          tags: latest 1 ${{ github.sha }} 1.5.9
+          tags: latest 1 ${{ github.sha }} 1.5.10
 
       - name: Push cwt-generator image to Quay.io
         id: push-to-quay

--- a/container_workflow_tool/sync.py
+++ b/container_workflow_tool/sync.py
@@ -97,8 +97,14 @@ class SyncHandler(object):
                     src_path_content = os.path.join(src_parent, dest_path_rel)
                     self.logger.debug(f"unlink {dest_file}")
                     os.unlink(dest_file)
-                    src_full = os.path.join(os.path.dirname(src_path_content),
-                                            os.readlink(src_path_content))
+                    # Catch exception in case of 'os.readlink(src_path_content)' does not exist.
+                    try:
+                        src_full = os.path.join(os.path.dirname(src_path_content),
+                                                os.readlink(src_path_content))
+                    except FileNotFoundError:
+                        self.logger.debug(f"Source file {src_path_content} does not exist."
+                                          f"It was deleted by upstream PR")
+                        continue
                     if os.path.isdir(src_full):
                         # In this case, when the source directory includes another symlinks outside
                         # of this directory, those wouldn't be fixed, so let's run the same function

--- a/container_workflow_tool/sync.py
+++ b/container_workflow_tool/sync.py
@@ -98,6 +98,9 @@ class SyncHandler(object):
                     self.logger.debug(f"unlink {dest_file}")
                     os.unlink(dest_file)
                     # Catch exception in case of 'os.readlink(src_path_content)' does not exist.
+                    # This code is used during update upstream -> downstream.
+                    # The row `os.unlink` above delete dest_file in case we delete it in upstream PR
+                    # But `os.readlink(src_path_content)` fail with traceback because of file does not exist
                     try:
                         src_full = os.path.join(os.path.dirname(src_path_content),
                                                 os.readlink(src_path_content))

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def get_dir(system_path=None, virtual_path=None):
 
 setup(
     name='container-workflow-tool',
-    version="1.5.9",
+    version="1.5.10",
     description='A python3 tool to make rebuilding images easier by automating several steps of the process.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Fix for 'src_path_content' in upstream does not exist
like was removed by PR,
then 'os.readlink(src_path_content)' failed with
traceback 'FileNotFoundError'.

See real error:
```
rh_cwt.main.distgit - DEBUG: unlink nginx-124/results/test/run-openshift Traceback (most recent call last):
  File "/usr/local/bin/rhcwt", line 8, in <module>
    sys.exit(run())
             ^^^^^
  File "/home/phracek/.local/lib/python3.12/site-packages/rh_cwt/cli.py", line 169, in run
    cli.run()
  File "/home/phracek/.local/lib/python3.12/site-packages/rh_cwt/cli.py", line 163, in run
    run_function()
  File "/home/phracek/.local/lib/python3.12/site-packages/rh_cwt/main.py", line 369, in dist_git_merge_changes
    super(RhelImageRebuilder, self).dist_git_merge_changes(rebase)
  File "/home/phracek/.local/lib/python3.12/site-packages/container_workflow_tool/main.py", line 578, in dist_git_merge_changes
    self.distgit.dist_git_merge_changes(images, rebase)
  File "/home/phracek/.local/lib/python3.12/site-packages/container_workflow_tool/distgit.py", line 99, in dist_git_merge_changes
    self.pull_upstream(component, path, url, repo, ups_name, commands)
  File "/home/phracek/.local/lib/python3.12/site-packages/container_workflow_tool/git_operations.py", line 259, in pull_upstream
    self.sync_handler.handle_dangling_symlinks(cp_path, component)
  File "/home/phracek/.local/lib/python3.12/site-packages/container_workflow_tool/sync.py", line 101, in handle_dangling_symlinks
    os.readlink(src_path_content))
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'upstreams/nginx/1.24/results/test/run-openshift'
```

























<!-- testing-farm = {"lock":"false","comment-id":"2467562937","data":[{"id":"7847e7a2-b094-4cdb-bb7b-470656af0c0b","name":"Fedora","runTime":540.651182,"created":"2024-11-12T15:18:23.481606","updated":"2024-11-12T15:18:23.481611","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/7847e7a2-b094-4cdb-bb7b-470656af0c0b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7847e7a2-b094-4cdb-bb7b-470656af0c0b/pipeline.log\">pipeline</a>"]}]} -->