### PR TITLE
Switch ubuntu-20.04 -> ubuntu-latest

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
ubuntu-20.04 is retired

<!-- testing-farm = {"lock":"false","comment-id":"2823235752","data":[{"id":"0976c23d-d1c8-42b7-ac4f-bdeaae17a6b8","name":"Fedora","runTime":424.576852,"created":"2025-04-23T06:37:27.648559","updated":"2025-04-23T06:37:27.648565","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/0976c23d-d1c8-42b7-ac4f-bdeaae17a6b8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0976c23d-d1c8-42b7-ac4f-bdeaae17a6b8/pipeline.log\">pipeline</a>"]}]} -->